### PR TITLE
Integrate broker target export

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,9 +2,6 @@ import os
 import time
 import logging
 from pathlib import Path
-from typing import Dict, List, Optional
-
-import pandas as pd
 import requests
 from dotenv import load_dotenv, find_dotenv
 
@@ -34,10 +31,11 @@ TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN", "").strip()
 TELEGRAM_CHAT_ID   = os.getenv("TELEGRAM_CHAT_ID", "").strip()
 
 # --- Projekt‑Module ---
-from wallenstein.stock_data import update_prices
-from wallenstein.db_utils import ensure_prices_view, get_latest_prices_auto
 from wallenstein.stock_data import update_prices, update_fx_rates
 from wallenstein.db_utils import ensure_prices_view, get_latest_prices
+from wallenstein.broker_targets import fetch_many
+from wallenstein.db_targets import save_snapshots
+from wallenstein.export_targets import export_latest_targets, export_latest_recs
 
 # ---------- Utils ----------
 def send_telegram(text: str) -> None:
@@ -59,25 +57,13 @@ def send_telegram(text: str) -> None:
     except Exception as e:
         log.error(f"Telegram SendError: {e}")
 
-def export_csv_targets(path: str, rows: List[dict]) -> None:
-    cols = ["timestamp_utc","ticker","price","target_low","target_mean","target_high","rec_text","rec_mean"]
-    pd.DataFrame(rows, columns=cols).to_csv(path, index=False, encoding="utf-8")
-
-def export_csv_recommendations(path: str, rows: List[dict]) -> None:
-    cols = ["timestamp_utc","ticker","price","target_low","target_mean","target_high",
-            "rec_text","rec_mean","broker_sig","reddit_score","combined_score","recommendation"]
-    pd.DataFrame(rows, columns=cols).to_csv(path, index=False, encoding="utf-8")
-
-def simple_recommendation(price: Optional[float]) -> str:
-    # Ohne Analysten/Reddit: neutral
-    return "Hold" if price is not None else "n/a"
 
 # ---------- Main ----------
 def main() -> int:
     t0 = time.time()
     log.info("🚀 Start Wallenstein: Pipeline-Run")
 
-    # 1) Kursdaten updaten (DB -> prices)
+    # 1) Kurse und FX-Daten aktualisieren
     try:
         added = update_prices(DB_PATH, TICKERS)
         if added:
@@ -85,83 +71,51 @@ def main() -> int:
     except Exception as e:
         log.error(f"❌ Kursupdate fehlgeschlagen: {e}")
 
-    # 2) View aktualisieren & aktuelle Preise laden
     try:
-        _ = ensure_prices_view(DB_PATH)
+        fx_added = update_fx_rates(DB_PATH)
+        log.info(f"FX-Update: +{fx_added} neue EURUSD-Zeilen")
     except Exception as e:
-        log.warning(f"View-Erstellung fehlgeschlagen/übersprungen: {e}")
+        log.error(f"❌ FX-Update fehlgeschlagen: {e}")
 
-    current_prices: Dict[str, Optional[float]] = {}
-    try:
-        current_prices = get_latest_prices_auto(DB_PATH, TICKERS)
-    except Exception as e:
-        log.error(f"❌ Lesen aktueller Preise fehlgeschlagen: {e}")
-        current_prices = {}
-
-    log.info(f"ℹ️ Aktuelle Preise: {current_prices}")
-
-        # 1) Kursdaten (USD) updaten
-    added = update_prices(DB_PATH, TICKERS)
-    # 1b) FX EURUSD updaten
-    fx_added = update_fx_rates(DB_PATH)
-    log.info(f"FX-Update: +{fx_added} neue EURUSD-Zeilen")
     ensure_prices_view(DB_PATH, view_name="stocks", table_name="prices")
     prices_usd = get_latest_prices(DB_PATH, TICKERS, use_eur=False)
     prices_eur = get_latest_prices(DB_PATH, TICKERS, use_eur=True)
     log.info(f"USD: {prices_usd} | EUR: {prices_eur}")
-   
+
     send_telegram(
-    "📊 Wallenstein Preise\n" +
-    "\n".join(
-        f"{t}: {prices_usd.get(t):.2f} USD | {prices_eur.get(t):.2f} EUR"
-        if prices_usd.get(t) is not None and prices_eur.get(t) is not None
-        else f"{t}: n/a"
-        for t in TICKERS
+        "📊 Wallenstein Preise\n" +
+        "\n".join(
+            f"{t}: {prices_usd.get(t):.2f} USD | {prices_eur.get(t):.2f} EUR"
+            if prices_usd.get(t) is not None and prices_eur.get(t) is not None
+            else f"{t}: n/a"
+            for t in TICKERS
+        )
     )
-)
 
-    # 3) CSV-Exporte (ohne Analysten – Platzhalterwerte)
-    now_utc = int(time.time())
-    targets_rows, reco_rows = [], []
-
-    for t in TICKERS:
-        price = current_prices.get(t)
-        targets_rows.append({
-            "timestamp_utc": now_utc,
-            "ticker": t,
-            "price": price,
-            "target_low": None,
-            "target_mean": None,
-            "target_high": None,
-            "rec_text": None,
-            "rec_mean": None,
-        })
-        reco_rows.append({
-            "timestamp_utc": now_utc,
-            "ticker": t,
-            "price": price,
-            "target_low": None,
-            "target_mean": None,
-            "target_high": None,
-            "rec_text": None,
-            "rec_mean": None,
-            "broker_sig": 0.0,
-            "reddit_score": 0.0,
-            "combined_score": 0.0,
-            "recommendation": simple_recommendation(price),
-        })
-
+    # 2) Broker-Ziele holen und speichern
     try:
-        export_csv_targets(TARGETS_CSV, targets_rows)
+        snapshots = fetch_many(TICKERS)
+        save_snapshots(DB_PATH, snapshots)
+    except Exception as e:
+        log.error(f"❌ Broker-Ziele fehlgeschlagen: {e}")
+
+    # 3) CSV-Exporte
+    try:
+        export_latest_targets(DB_PATH, TARGETS_CSV, TICKERS)
         log.info(f"✅ price_targets.csv exportiert → {TARGETS_CSV}")
     except Exception as e:
         log.error(f"❌ Export price_targets.csv fehlgeschlagen: {e}")
 
     try:
-        export_csv_recommendations(RECO_CSV, reco_rows)
+        export_latest_recs(DB_PATH, RECO_CSV, TICKERS)
         log.info(f"✅ recommendations.csv exportiert → {RECO_CSV}")
     except Exception as e:
         log.error(f"❌ Export recommendations.csv fehlgeschlagen: {e}")
 
+    log.info(f"🏁 Fertig in {time.time() - t0:.1f}s")
+    return 0
+
+
 if __name__ == "__main__":
     raise SystemExit(main())
+

--- a/wallenstein/export_targets.py
+++ b/wallenstein/export_targets.py
@@ -28,3 +28,50 @@ def export_latest_targets(db_path: str, csv_path: str, tickers: list[str]):
     # Export
     df.to_csv(csv_path, index=False)
     return df
+
+
+def export_latest_recs(db_path: str, csv_path: str, tickers: list[str]):
+    """Exportiert die jüngsten Empfehlungen inkl. einfacher Bewertung."""
+    con = duckdb.connect(db_path)
+    q = """
+    WITH ranked AS (
+      SELECT *,
+             ROW_NUMBER() OVER (PARTITION BY ticker ORDER BY fetched_at_utc DESC) AS rn
+      FROM broker_targets
+      WHERE ticker IN ({})
+    )
+    SELECT ticker,
+           to_timestamp(fetched_at_utc) AS fetched_at,
+           target_mean, target_high, target_low,
+           rec_mean, rec_text,
+           strong_buy, buy, hold, sell, strong_sell,
+           source
+    FROM ranked
+    WHERE rn = 1
+    ORDER BY ticker;
+    """.format(", ".join(["'{}'".format(t) for t in tickers]))
+    df = con.execute(q).fetch_df()
+    con.close()
+
+    # Zusätzliche Kennzahlen (Broker-Signal, Platzhalter für Reddit etc.)
+    def _broker_sig(v):
+        try:
+            return 0.0 if pd.isna(v) else 3.0 - float(v)
+        except Exception:
+            return 0.0
+
+    df["broker_sig"] = df["rec_mean"].apply(_broker_sig)
+    df["reddit_score"] = 0.0
+    df["combined_score"] = df["broker_sig"] + df["reddit_score"]
+
+    def _reco(score):
+        if score > 0.5:
+            return "Buy"
+        if score < -0.5:
+            return "Sell"
+        return "Hold"
+
+    df["recommendation"] = df["combined_score"].apply(_reco)
+    df.to_csv(csv_path, index=False)
+    return df
+


### PR DESCRIPTION
## Summary
- Fetch broker target snapshots for configured tickers and store them in DuckDB.
- Export latest price targets and recommendations to CSV using new helper functions.
- Provide export utility for recommendations with simple scoring logic.

## Testing
- `python -m py_compile main.py wallenstein/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8d630c8e88325a6486dffc47882a5