### PR TITLE
Normalize Finnhub error snippets

### DIFF
--- a/wallenstein/broker_targets.py
+++ b/wallenstein/broker_targets.py
@@ -79,7 +79,7 @@ def _finnhub_get(path: str, params: Dict[str, Any]) -> Dict[str, Any]:
     try:
         return r.json()
     except ValueError as e:
-        snippet = r.text[:200].strip()
+        snippet = " ".join(r.text.split())[:200]
         log.error("Finnhub JSON decode failed [%s]: %s", r.status_code, snippet)
         raise FinnhubResponseError(r.status_code, snippet) from e
 


### PR DESCRIPTION
## Summary
- Normalize Finnhub response snippets before truncation
- Ensure logs and errors include a single-line ~200 char snippet when JSON decoding fails

## Testing
- `pytest -q`
- `python -m py_compile wallenstein/broker_targets.py`
- `python - <<'PY'
import logging
from wallenstein import broker_targets as bt
bt.FINNHUB_BASE_URL = "http://localhost:8000"
logging.basicConfig(level=logging.ERROR)
try:
    bt._finnhub_get("", {})
except bt.FinnhubResponseError as e:
    print('Captured snippet length:', len(e.snippet))
    print('Snippet:', e.snippet)
PY`
- `python - <<'PY'
import logging, io
from wallenstein import broker_targets as bt
bt.FINNHUB_BASE_URL = "http://localhost:8000"
log_stream = io.StringIO()
handler = logging.StreamHandler(log_stream)
logger = logging.getLogger("wallenstein.targets")
logger.setLevel(logging.ERROR)
logger.addHandler(handler)
try:
    bt._finnhub_get("", {})
except bt.FinnhubResponseError:
    pass
logger.removeHandler(handler)
output = log_stream.getvalue()
print(repr(output))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a8e0bc7b4083259ed7ea0f98314209