### PR TITLE
Send broker price targets via Telegram

### DIFF
--- a/main.py
+++ b/main.py
@@ -96,6 +96,17 @@ def main() -> int:
     try:
         snapshots = fetch_many(TICKERS)
         save_snapshots(DB_PATH, snapshots)
+        if snapshots:
+            lines = []
+            for s in snapshots:
+                if "error" in s:
+                    lines.append(f"{s.get('ticker')}: {s['error']}")
+                else:
+                    lines.append(
+                        f"{s.get('ticker')}: mean {s.get('target_mean', 'n/a')} "
+                        f"high {s.get('target_high', 'n/a')} low {s.get('target_low', 'n/a')}"
+                    )
+            send_telegram("🎯 Broker Price Targets\n" + "\n".join(lines))
     except Exception as e:
         log.error(f"❌ Broker-Ziele fehlgeschlagen: {e}")
 

--- a/wallenstein/broker_targets.py
+++ b/wallenstein/broker_targets.py
@@ -79,7 +79,7 @@ def _finnhub_get(path: str, params: Dict[str, Any]) -> Dict[str, Any]:
     try:
         return r.json()
     except ValueError as e:
-        snippet = r.text[:200].strip()
+        snippet = " ".join(r.text.split())[:200]
         log.error("Finnhub JSON decode failed [%s]: %s", r.status_code, snippet)
         raise FinnhubResponseError(r.status_code, snippet) from e
 


### PR DESCRIPTION
## Summary
- Add Telegram message summarizing broker price targets with mean, high and low for each ticker or error messages.

## Testing
- `pytest -q`
- `python -m py_compile main.py`
- `python - <<'PY'
import main
snapshots = [
    {'ticker': 'NVDA', 'target_mean': 100.0, 'target_high': 120.0, 'target_low': 90.0},
    {'ticker': 'AMZN', 'error': 'HTTP 429'},
]
lines = []
for s in snapshots:
    if 'error' in s:
        lines.append(f"{s.get('ticker')}: {s['error']}")
    else:
        lines.append(
            f"{s.get('ticker')}: mean {s.get('target_mean', 'n/a')} "
            f"high {s.get('target_high', 'n/a')} low {s.get('target_low', 'n/a')}"
        )
print('\n'.join(lines))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a8e0bc7b4083259ed7ea0f98314209