### PR TITLE
Remove stray codex lines from broker targets

### DIFF
--- a/main.py
+++ b/main.py
@@ -102,7 +102,6 @@ def main() -> int:
                 if "error" in s:
                     lines.append(f"{s.get('ticker')}: {s['error']}")
                 else:
-codex/normalize-and-log-finnhub-response-snippet-ggbtlc
                     mean = s.get("target_mean")
                     high = s.get("target_high")
                     low = s.get("target_low")
@@ -110,11 +109,6 @@ codex/normalize-and-log-finnhub-response-snippet-ggbtlc
                         f"{s.get('ticker')}: mean {mean if mean is not None else 'n/a'} "
                         f"high {high if high is not None else 'n/a'} "
                         f"low {low if low is not None else 'n/a'}"
-
-                    lines.append(
-                        f"{s.get('ticker')}: mean {s.get('target_mean', 'n/a')} "
-                        f"high {s.get('target_high', 'n/a')} low {s.get('target_low', 'n/a')}"
- main
                     )
             send_telegram("🎯 Broker Price Targets\n" + "\n".join(lines))
     except Exception as e:

--- a/wallenstein/broker_targets.py
+++ b/wallenstein/broker_targets.py
@@ -79,11 +79,7 @@ def _finnhub_get(path: str, params: Dict[str, Any]) -> Dict[str, Any]:
     try:
         return r.json()
     except ValueError as e:
- codex/normalize-and-log-finnhub-response-snippet-ggbtlc
         snippet = " ".join(r.text.split())[:200]  # normalize and truncate
-
-        snippet = " ".join(r.text.split())[:200]
- main
         log.error("Finnhub JSON decode failed [%s]: %s", r.status_code, snippet)
         raise FinnhubResponseError(r.status_code, snippet) from e
 


### PR DESCRIPTION
## Summary
- remove stray codex markers and cleanup formatting in broker target sections
- tidy Finnhub API error handling snippet

## Testing
- `python -m py_compile main.py`
- `python -m py_compile wallenstein/broker_targets.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8eaba44688325881ffab9cfc44bef