### PR TITLE
Use FMP API for broker targets

### DIFF
--- a/wallenstein/broker_targets.py
+++ b/wallenstein/broker_targets.py
@@ -1,7 +1,7 @@
 # wallenstein/broker_targets.py
 from __future__ import annotations
 
-"""Fetch analyst price targets and recommendations using the Finnhub API."""
+"""Fetch analyst price targets and recommendations using the FMP API."""
 
 import logging
 import os
@@ -14,17 +14,9 @@ from urllib3.util.retry import Retry
 
 log = logging.getLogger("wallenstein.targets")
 
-FINNHUB_TOKEN = os.getenv("FINNHUB_TOKEN", "demo")
-FINNHUB_BASE_URL = "https://finnhub.io/api/v1"
-
-
-class FinnhubResponseError(Exception):
-    """Raised when Finnhub returns a non-JSON response."""
-
-    def __init__(self, status: int, snippet: str):
-        super().__init__(f"HTTP {status}: {snippet}")
-        self.status = status
-        self.snippet = snippet
+# FMP configuration
+FMP_API_KEY = os.getenv("FMP_API_KEY", "demo")
+FMP_BASE_URL = "https://financialmodelingprep.com/api/v4"
 
 
 # ---------------------------------------------------------------------------
@@ -68,57 +60,60 @@ def _pos(x: Optional[float]) -> Optional[float]:
     return x if (x is not None and x > 0) else None
 
 
-def _finnhub_get(path: str, params: Dict[str, Any]) -> Dict[str, Any]:
-    """Perform a GET request against the Finnhub API and return JSON."""
+def _fmp_get(path: str, params: Dict[str, Any]) -> Dict[str, Any]:
+    """Perform a GET request against the FMP API and return JSON."""
 
     params = dict(params)
-    params["token"] = FINNHUB_TOKEN
-    url = f"{FINNHUB_BASE_URL}/{path}"
+    params["apikey"] = FMP_API_KEY
+    url = f"{FMP_BASE_URL}/{path}"
     r = _SESSION.get(url, params=params, timeout=10.0)
     r.raise_for_status()
-    try:
-        return r.json()
-    except ValueError as e:
-        snippet = " ".join(r.text.split())[:200]  # normalize and truncate
-        log.error("Finnhub JSON decode failed [%s]: %s", r.status_code, snippet)
-        raise FinnhubResponseError(r.status_code, snippet) from e
+    return r.json()
 
 
 # ---------------------------------------------------------------------------
-# Finnhub specific helpers
+# FMP specific helpers
 # ---------------------------------------------------------------------------
-def _price_targets(ticker: str) -> Dict[str, Optional[float]]:
-    """Return mean/high/low analyst price targets for ``ticker``."""
+def _fmp_price_target(ticker: str) -> Dict[str, Optional[float]]:
+    """Return price targets and recommendation counts for ``ticker``."""
 
-    out = {"mean": None, "high": None, "low": None}
+    out: Dict[str, Optional[float]] = {
+        "target_mean": None,
+        "target_high": None,
+        "target_low": None,
+        "strong_buy": None,
+        "buy": None,
+        "hold": None,
+        "sell": None,
+        "strong_sell": None,
+    }
     try:
-        data = _finnhub_get("price-target", {"symbol": ticker})
-        out["mean"] = _pos(_sf(data.get("targetMean")))
-        out["high"] = _pos(_sf(data.get("targetHigh")))
-        out["low"] = _pos(_sf(data.get("targetLow")))
-    except FinnhubResponseError as e:
-        log.warning(f"[{ticker}] price-target error: {e}")
+        data = _fmp_get("price-target", {"symbol": ticker})
+        item = data[0] if isinstance(data, list) and data else {}
+        out["target_mean"] = _pos(
+            _sf(
+                item.get("targetMean")
+                or item.get("priceTargetAverage")
+                or item.get("targetConsensus")
+            )
+        )
+        out["target_high"] = _pos(
+            _sf(item.get("targetHigh") or item.get("priceTargetHigh"))
+        )
+        out["target_low"] = _pos(
+            _sf(item.get("targetLow") or item.get("priceTargetLow"))
+        )
+        out["strong_buy"] = (
+            item.get("strongBuy") or item.get("ratingStrongBuy")
+        )
+        out["buy"] = item.get("buy") or item.get("ratingBuy")
+        out["hold"] = item.get("hold") or item.get("ratingHold")
+        out["sell"] = item.get("sell") or item.get("ratingSell")
+        out["strong_sell"] = (
+            item.get("strongSell") or item.get("ratingStrongSell")
+        )
     except Exception as e:
         log.warning(f"[{ticker}] price-target error: {e}")
-    return out
-
-
-def _recommendation_counts(ticker: str) -> Dict[str, Optional[int]]:
-    """Return latest analyst recommendation counts for ``ticker``."""
-
-    out = {"strong_buy": None, "buy": None, "hold": None, "sell": None, "strong_sell": None}
-    try:
-        data = _finnhub_get("stock/recommendation", {"symbol": ticker})
-        latest = data[0] if isinstance(data, list) and data else {}
-        out["strong_buy"] = latest.get("strongBuy")
-        out["buy"] = latest.get("buy")
-        out["hold"] = latest.get("hold")
-        out["sell"] = latest.get("sell")
-        out["strong_sell"] = latest.get("strongSell")
-    except FinnhubResponseError as e:
-        log.warning(f"[{ticker}] recommendation error: {e}")
-    except Exception as e:
-        log.warning(f"[{ticker}] recommendation error: {e}")
     return out
 
 
@@ -152,23 +147,26 @@ def _compute_rec_text(mean: Optional[float]) -> Optional[str]:
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
-def fetch_broker_snapshot(ticker: str, *, sleep_after: float = 0.4) -> Dict[str, Any]:
-    """Fetch a broker snapshot for a single ``ticker`` using Finnhub."""
+def fetch_broker_snapshot(ticker: str) -> Dict[str, Any]:
+    """Fetch a broker snapshot for a single ``ticker`` using FMP."""
 
     now = int(time.time())
-    targets = _price_targets(ticker)
-    counts = _recommendation_counts(ticker)
+    data = _fmp_price_target(ticker)
+    counts = {
+        "strong_buy": data.get("strong_buy"),
+        "buy": data.get("buy"),
+        "hold": data.get("hold"),
+        "sell": data.get("sell"),
+        "strong_sell": data.get("strong_sell"),
+    }
     rec_mean = _compute_rec_mean(counts)
     rec_text = _compute_rec_text(rec_mean)
 
-    if sleep_after:
-        time.sleep(sleep_after)
-
     return {
         "ticker": ticker,
-        "target_mean": targets.get("mean"),
-        "target_high": targets.get("high"),
-        "target_low": targets.get("low"),
+        "target_mean": data.get("target_mean"),
+        "target_high": data.get("target_high"),
+        "target_low": data.get("target_low"),
         "rec_mean": rec_mean,
         "rec_text": rec_text,
         "strong_buy": counts.get("strong_buy"),
@@ -176,27 +174,28 @@ def fetch_broker_snapshot(ticker: str, *, sleep_after: float = 0.4) -> Dict[str,
         "hold": counts.get("hold"),
         "sell": counts.get("sell"),
         "strong_sell": counts.get("strong_sell"),
-        "source": "finnhub.price-target + finnhub.stock/recommendation",
+        "source": "fmp.price-target",
         "fetched_at_utc": now,
     }
 
 
-def fetch_many(tickers: List[str]) -> List[Dict[str, Any]]:
+def fetch_many(tickers: List[str], *, sleep_between: float = 0.25) -> List[Dict[str, Any]]:
     """Fetch broker snapshots for multiple tickers."""
 
     out: List[Dict[str, Any]] = []
     for t in tickers:
         try:
-            out.append(fetch_broker_snapshot(t, sleep_after=0.5))
+            out.append(fetch_broker_snapshot(t))
         except Exception as e:
             out.append(
                 {
                     "ticker": t,
                     "error": str(e),
-                    "source": "finnhub",
+                    "source": "fmp",
                     "fetched_at_utc": int(time.time()),
                 }
             )
-            time.sleep(0.6)
+        if sleep_between:
+            time.sleep(sleep_between)
     return out
 


### PR DESCRIPTION
## Summary
- replace Finnhub integration with Financial Modeling Prep price target API
- record price targets and recommendation counts from FMP response
- throttle multi-ticker requests with small sleep between calls

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a9ba264540832585bea8bf21ba590f