### PR TITLE
Expand price target field aliases

### DIFF
--- a/wallenstein/broker_targets.py
+++ b/wallenstein/broker_targets.py
@@ -100,10 +100,26 @@ def _parse_price_target_item(item: Dict[str, Any]) -> Dict[str, Optional[float]]
         return None
 
     return {
-        "target_mean": _pos(_sf(_first("targetConsensus", "priceTargetAverage"))),
-        "target_high": _pos(_sf(_first("targetHigh", "priceTargetHigh"))),
-        "target_low": _pos(_sf(_first("targetLow", "priceTargetLow"))),
-        "target_median": _pos(_sf(_first("targetMedian", "priceTargetMedian"))),
+        "target_mean": _pos(
+            _sf(
+                _first(
+                    "targetConsensus",
+                    "priceTargetAverage",
+                    "priceTarget",
+                    "targetPrice",
+                    "targetMean",
+                )
+            )
+        ),
+        "target_high": _pos(
+            _sf(_first("targetHigh", "priceTargetHigh", "targetPriceHigh"))
+        ),
+        "target_low": _pos(
+            _sf(_first("targetLow", "priceTargetLow", "targetPriceLow"))
+        ),
+        "target_median": _pos(
+            _sf(_first("targetMedian", "priceTargetMedian", "targetPriceMedian"))
+        ),
     }
 
 


### PR DESCRIPTION
## Summary
- handle additional price target field names like `priceTarget`, `targetPrice`, and `targetMean`
- support `targetPriceHigh/Low/Median` fallbacks when parsing FMP price targets

## Testing
- `python -m py_compile wallenstein/broker_targets.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9d6f0bc5483259761dd19105c7cf4