### PR TITLE
test: cover FMP price target API helper

### DIFF
--- a/tests/test_broker_targets_api.py
+++ b/tests/test_broker_targets_api.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import wallenstein.broker_targets as bt
+
+
+def test_fmp_get_request_is_made_once_with_api_key(requests_mock, monkeypatch):
+    monkeypatch.setattr(bt, "FMP_API_KEY", "test-key")
+    url = "https://financialmodelingprep.com/api/v4/price-target-consensus"
+    payload = {"foo": "bar"}
+    requests_mock.get(url, json=payload)
+
+    result = bt._fmp_get("price-target-consensus", {"symbol": "AAPL"})
+
+    assert result == payload
+    assert requests_mock.call_count == 1
+    req = requests_mock.last_request
+    assert req.qs["apikey"] == ["test-key"]
+


### PR DESCRIPTION
## Summary
- test broker target helper `_fmp_get` using mocked HTTP and patched API key

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9da348af48325babed37c8a65969e