### PR TITLE
Add pytest fixture for broker targets API test

### DIFF
--- a/tests/test_broker_targets_api.py
+++ b/tests/test_broker_targets_api.py
@@ -1,9 +1,16 @@
 from pathlib import Path
 import sys
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import wallenstein.broker_targets as bt
+
+
+@pytest.fixture
+def api_key():
+    return "test-key"
 
 
 def test_fmp_get_request_is_made_once_with_api_key(requests_mock, monkeypatch):


### PR DESCRIPTION
## Summary
- import pytest in broker targets API tests
- add api_key fixture for tests

## Testing
- `pytest tests/test_broker_targets_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9dd7c4f5c83258a6d01fbe2b757e3