### PR TITLE
Log snapshot dictionaries after fetch

### DIFF
--- a/main.py
+++ b/main.py
@@ -75,6 +75,8 @@ def main() -> int:
         log.error(f"❌ FX-Update fehlgeschlagen: {e}")
 
     snapshots = fetch_many(TICKERS)
+    for snap in snapshots:
+        print(snap)        # or use log.info(snap)
     save_snapshots(DB_PATH, snapshots)
     df = export_latest_targets(DB_PATH, Path(STOCK_OVERVIEW_DIR) / "targets.csv", TICKERS)
 


### PR DESCRIPTION
## Summary
- Print each snapshot dictionary after fetching price targets for easier inspection

## Testing
- `python main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a9e17ab4408325a896636927bb0b4c