### PR TITLE
docs: update README for broker-target hiatus

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 This is a ready-to-push bundle. It includes:
 - Robust price updater with DuckDB storage
-- Broker targets & recommendations (Yahoo QuoteSummary)
 - Reddit sentiment integration (PRAW)
 - Telegram alerts (optional)
-- CSV exports in `stockOverview/`
+
+Broker-target support is temporarily disabled pending a new data provider.
 
 ## Quickstart
 ```bash
@@ -26,12 +26,10 @@ python main.py
 ├─ requirements.txt
 ├─ .env.example
 ├─ data/                  # DuckDB lives here
-├─ stockOverview/         # CSV exports
 └─ wallenstein/
    ├─ __init__.py
    ├─ stock_data.py
    ├─ db_utils.py
-   ├─ broker_targets.py
    ├─ reddit_scraper.py
    └─ sentiment.py
 ```


### PR DESCRIPTION
## Summary
- drop references to broker-targets and CSV exports
- note that broker-target support is temporarily disabled pending a new data provider

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a9e9aec5088325adf80e1e3e75a0de