### PR TITLE
Add per-stock logistic regression model and tests

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from wallenstein.models import train_per_stock
+
+
+def test_train_per_stock_basic():
+    dates = pd.date_range("2024-01-01", periods=10, freq="D")
+    df = pd.DataFrame({
+        "date": dates,
+        "close": [1, 2, 1.5, 1.8, 2.2, 2.1, 2.3, 2.5, 2.4, 2.6],
+        "sentiment": [0.1, -0.2, 0.0, 0.3, 0.5, -0.1, 0.2, 0.1, -0.2, 0.3],
+    })
+    acc = train_per_stock(df)
+    assert acc is not None
+    assert 0.0 <= acc <= 1.0
+
+
+def test_train_per_stock_insufficient_classes():
+    dates = pd.date_range("2024-01-01", periods=5, freq="D")
+    df = pd.DataFrame({
+        "date": dates,
+        "close": [1, 1, 1, 1, 1],  # no variation -> only one class
+        "sentiment": [0, 0, 0, 0, 0],
+    })
+    acc = train_per_stock(df)
+    assert acc is None

--- a/wallenstein/models.py
+++ b/wallenstein/models.py
@@ -1,0 +1,63 @@
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import accuracy_score
+from typing import Optional
+
+
+def train_per_stock(df_stock: pd.DataFrame) -> Optional[float]:
+    """Train a simple LogisticRegression on lagged close and sentiment data.
+
+    Parameters
+    ----------
+    df_stock : pd.DataFrame
+        DataFrame containing at least ``date``, ``close`` and ``sentiment`` columns.
+        The function will sort by date, create lagged features of ``close`` and
+        ``sentiment`` and attempt to predict if the next day's close is higher
+        than the previous day's.
+
+    Returns
+    -------
+    Optional[float]
+        Accuracy of the model on the hold‑out test set. ``None`` is returned if
+        there are insufficient samples or only one class in the training data.
+    """
+
+    if df_stock.empty:
+        return None
+
+    df = df_stock.sort_values("date").copy()
+    df["sentiment"] = df["sentiment"].fillna(0)
+
+    # Lagged features
+    df["Close_lag1"] = df["close"].shift(1)
+    df["Sentiment_lag1"] = df["sentiment"].shift(1)
+    df["y"] = (df["close"] > df["Close_lag1"]).astype(int)
+    df.dropna(inplace=True)
+
+    if len(df) < 2:
+        return None
+
+    train_size = max(int(len(df) * 0.8), 1)
+    df_train = df.iloc[:train_size]
+    df_test = df.iloc[train_size:]
+
+    X_train = df_train[["Close_lag1", "Sentiment_lag1"]]
+    y_train = df_train["y"]
+
+    # Need at least two classes to train logistic regression
+    if y_train.nunique() < 2:
+        return None
+
+    model = LogisticRegression()
+    model.fit(X_train, y_train)
+
+    if df_test.empty:
+        y_pred = model.predict(X_train)
+        accuracy = accuracy_score(y_train, y_pred)
+    else:
+        X_test = df_test[["Close_lag1", "Sentiment_lag1"]]
+        y_test = df_test["y"]
+        y_pred = model.predict(X_test)
+        accuracy = accuracy_score(y_test, y_pred)
+
+    return float(accuracy)


### PR DESCRIPTION
## Summary
- Add `train_per_stock` for lag-based sentiment and price logistic regression
- Extend main pipeline to merge price/sentiment data and train model per ticker
- Cover model training edge cases with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9fd6f1f3883258d79c56e8976aeda