### PR TITLE
Add daily Reddit sentiment aggregation

### DIFF
--- a/main.py
+++ b/main.py
@@ -46,7 +46,7 @@ TELEGRAM_CHAT_ID = os.getenv("TELEGRAM_CHAT_ID", "").strip()
 # --- Projekt‑Module ---
 from wallenstein.stock_data import update_prices, update_fx_rates
 from wallenstein.db_utils import ensure_prices_view, get_latest_prices
-from wallenstein.sentiment import analyze_sentiment, derive_recommendation
+from wallenstein.sentiment import build_daily_sentiment, derive_recommendation
 
 
 # ---------- Main ----------
@@ -83,15 +83,15 @@ def main() -> int:
     prices_usd = get_latest_prices(DB_PATH, TICKERS, use_eur=False)
     log.info(f"USD: {prices_usd}")
 
+    all_posts = [p for posts in reddit_posts.values() for p in posts]
+    df_sentiment = build_daily_sentiment(all_posts, TICKERS)
     sentiments = {}
-    for ticker, texts in reddit_posts.items():
-        texts = list(texts)
-        if texts:
-            # update_reddit_data returns dicts with keys {"created_utc", "text"}
-            scores = [analyze_sentiment(t["text"]) for t in texts]
-            sentiments[ticker] = sum(scores) / len(scores)
+    for t in TICKERS:
+        df_t = df_sentiment[df_sentiment["Stock"] == t]
+        if not df_t.empty:
+            sentiments[t] = df_t.sort_values("Date")["Sentiment"].iloc[-1]
         else:
-            sentiments[ticker] = 0.0
+            sentiments[t] = 0.0
 
     price_lines = []
     sentiment_lines = []

--- a/wallenstein/__init__.py
+++ b/wallenstein/__init__.py
@@ -4,10 +4,12 @@ from .sentiment import (
     aggregate_sentiment_by_ticker,
     analyze_sentiment,
     derive_recommendation,
+    build_daily_sentiment,
 )
 
 __all__ = [
     "aggregate_sentiment_by_ticker",
     "analyze_sentiment",
     "derive_recommendation",
+    "build_daily_sentiment",
 ]

--- a/wallenstein/stock_keywords.py
+++ b/wallenstein/stock_keywords.py
@@ -1,0 +1,14 @@
+"""Synonyms for stock ticker matching."""
+
+from __future__ import annotations
+
+# Mapping of ticker symbols to a list of synonyms.
+global_synonyms = {
+    "AAPL": ["AAPL", "Apple", "MacBook", "iPhone", "Tim Cook", "iOS", "Apfel"],
+    "NVDA": ["NVDA", "Nvidia", "RTX", "GeForce", "AI Chips", "GPU"],
+    "TSLA": ["TSLA", "Tesla", "Elon Musk", "Cybertruck", "EV", "Model 3"],
+    "MSFT": ["MSFT", "Microsoft", "Windows", "Azure", "Satya Nadella", "Xbox"],
+    "RHM.DE": ["RHM.DE", "Rheiner", "Rheinmetall", "Rüstung"],
+}
+
+__all__ = ["global_synonyms"]


### PR DESCRIPTION
## Summary
- Port legacy stock synonym list to `wallenstein/stock_keywords.py`
- Implement `build_daily_sentiment` to map posts to tickers via synonyms and average daily sentiment
- Use new aggregation in `main.py` and expose it at the package level

## Testing
- `python -m py_compile main.py wallenstein/sentiment.py wallenstein/__init__.py wallenstein/stock_keywords.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9fd6d76988325b164485eefbcd2d7