### PR TITLE
Prevent duplicate reddit posts

### DIFF
--- a/wallenstein/reddit_scraper.py
+++ b/wallenstein/reddit_scraper.py
@@ -142,7 +142,9 @@ def update_reddit_data(
                 """
             )
             con.register("df_all", df_all)
-            con.execute("INSERT OR REPLACE INTO reddit_posts SELECT * FROM df_all")
+            con.execute(
+                "INSERT INTO reddit_posts SELECT * FROM df_all ON CONFLICT(id) DO NOTHING"
+            )
         log.info(f"Wrote {len(df_all)} posts to reddit_posts")
 
     # Alte Einträge entfernen


### PR DESCRIPTION
## Summary
- Define `reddit_posts.id` as `VARCHAR PRIMARY KEY`
- Skip inserting duplicate reddit posts with `ON CONFLICT(id) DO NOTHING`

## Testing
- `python main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa0323ca98832598528daa3860f416