### PR TITLE
Ensure reddit_posts has unique id index

### DIFF
--- a/wallenstein/reddit_scraper.py
+++ b/wallenstein/reddit_scraper.py
@@ -134,12 +134,24 @@ def update_reddit_data(
             con.execute(
                 """
                 CREATE TABLE IF NOT EXISTS reddit_posts (
-                    id VARCHAR PRIMARY KEY,
+                    id VARCHAR,
                     title VARCHAR,
                     created_utc TIMESTAMP,
                     text VARCHAR
                 )
                 """
+            )
+            # Ensure uniqueness on id for existing tables
+            con.execute(
+                """
+                DELETE FROM reddit_posts
+                WHERE rowid NOT IN (
+                    SELECT MIN(rowid) FROM reddit_posts GROUP BY id
+                )
+                """
+            )
+            con.execute(
+                "CREATE UNIQUE INDEX IF NOT EXISTS reddit_posts_id_idx ON reddit_posts(id)"
             )
             con.register("df_all", df_all)
             con.execute(


### PR DESCRIPTION
## Summary
- Enforce unique `id` in `reddit_posts` even for existing tables by removing duplicates and creating a unique index
- Maintain upsert logic for inserting posts without conflicts

## Testing
- `python main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aa115de008832581fbc49987cdd10b