### PR TITLE
Ensure sentiment dtype after fillna

### DIFF
--- a/wallenstein/models.py
+++ b/wallenstein/models.py
@@ -26,7 +26,7 @@ def train_per_stock(df_stock: pd.DataFrame) -> Optional[float]:
         return None
 
     df = df_stock.sort_values("date").copy()
-    df["sentiment"] = df["sentiment"].fillna(0)
+    df["sentiment"] = df["sentiment"].fillna(0).infer_objects(copy=False)
 
     # Lagged features
     df["Close_lag1"] = df["close"].shift(1)


### PR DESCRIPTION
## Summary
- ensure sentiment column maintains correct dtype after filling missing values in `train_per_stock`

## Testing
- `pytest tests/test_models.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa1161e9cc8325b2fdab23f546373a