### PR TITLE
Expand sentiment keywords for better classification

### DIFF
--- a/tests/test_sentiment.py
+++ b/tests/test_sentiment.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from wallenstein.sentiment import analyze_sentiment, aggregate_sentiment_by_ticker, derive_recommendation
+
+def test_analyze_sentiment_keywords():
+    text = "I'm going long and want to buy more calls, not sell"
+    assert analyze_sentiment(text) > 0
+    text2 = "Time to sell and go short, very bearish"
+    assert analyze_sentiment(text2) < 0
+
+
+def test_aggregate_and_recommendation():
+    data = {
+        "NVDA": [{"text": "buy the dip"}, {"text": "bullish"}],
+        "AMZN": [{"text": "sell now"}]
+    }
+    scores = aggregate_sentiment_by_ticker(data)
+    assert scores["NVDA"] > 0
+    assert scores["AMZN"] < 0
+    assert derive_recommendation(scores["NVDA"]) == "Buy"
+    assert derive_recommendation(scores["AMZN"]) == "Sell"
+    assert derive_recommendation(0.0) == "Hold"

--- a/wallenstein/sentiment.py
+++ b/wallenstein/sentiment.py
@@ -5,24 +5,36 @@ from __future__ import annotations
 from typing import Dict, Iterable
 
 # keyword -> sentiment score mapping used by :func:`analyze_sentiment`
+#
+# Many retail traders express their sentiment using simple words like
+# ``"buy"`` or ``"sell"``.  The previous implementation only looked for
+# option‑related terms (``"call"``/``"put"``) or metaphors such as
+# ``"bullish"`` and therefore returned ``0`` for common phrases like
+# "buy the dip".  This resulted in neutral recommendations even when the
+# text clearly contained a directional bias.  To improve coverage we map
+# a couple of additional keywords to sentiment scores.
 KEYWORD_SCORES: Dict[str, int] = {
+    # positive
     "long": 1,
     "call": 1,
     "bull": 1,
     "bullish": 1,
+    "buy": 1,
+    # negative
     "short": -1,
     "put": -1,
     "bear": -1,
     "bearish": -1,
+    "sell": -1,
 }
 
 
 def analyze_sentiment(text: str) -> float:
     """Return a simplistic sentiment score for ``text``.
 
-    Positive sentiment is counted for occurrences of ``"long"``, ``"call"``,
-    ``"bull"`` or ``"bullish"`` while ``"short"``, ``"put"``, ``"bear`` and
-    ``"bearish"`` contribute negative sentiment.
+    Positive sentiment is counted for occurrences of words such as ``"long"``,
+    ``"call"``, ``"bullish"`` or ``"buy"``.  Negative sentiment is triggered by
+    phrases like ``"short"``, ``"put"``, ``"bearish"`` or ``"sell"``.
     """
 
     text = text.lower()


### PR DESCRIPTION
## Summary
- broaden sentiment keyword mapping to capture common "buy"/"sell" phrases
- document the additional sentiment terms
- add unit tests for sentiment helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa12942e38832592c5f5811d81ad56