### PR TITLE
Handle non-numeric sentiment values

### DIFF
--- a/wallenstein/models.py
+++ b/wallenstein/models.py
@@ -26,7 +26,7 @@ def train_per_stock(df_stock: pd.DataFrame) -> Optional[float]:
         return None
 
     df = df_stock.sort_values("date").copy()
-    df["sentiment"] = df["sentiment"].fillna(0).infer_objects(copy=False)
+    df["sentiment"] = pd.to_numeric(df["sentiment"], errors="coerce").fillna(0)
 
     # Lagged features
     df["Close_lag1"] = df["close"].shift(1)


### PR DESCRIPTION
## Summary
- Ensure `train_per_stock` converts sentiment column to numeric with `pd.to_numeric` and fills NaNs with 0

## Testing
- `pytest -q`
- `python - <<'PY'
import pandas as pd
from wallenstein.models import train_per_stock
import warnings
with warnings.catch_warnings(record=True) as w:
    warnings.simplefilter('always')
    df = pd.DataFrame({'date': pd.date_range('2024', periods=5), 'close': [1,2,3,4,5], 'sentiment': ['0.1', 'NaN', 'foo', '0.3', None]})
    acc = train_per_stock(df)
    print('accuracy:', acc)
    print('warnings:', [type(warn.message).__name__ + ': ' + str(warn.message) for warn in w])
PY`


------
https://chatgpt.com/codex/tasks/task_e_68aa13fe5ba0832589b4ed38d0307314