### PR TITLE
Add German sentiment keywords and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a ready-to-push bundle. It includes:
 - Robust price updater with DuckDB storage
-- Reddit sentiment integration (PRAW)
+- Reddit sentiment integration (PRAW) with basic English/German keyword analysis
 - Telegram alerts (optional)
 
 Broker-target support is temporarily disabled pending a new data provider.

--- a/tests/test_sentiment.py
+++ b/tests/test_sentiment.py
@@ -12,12 +12,16 @@ def test_analyze_sentiment_keywords():
     assert analyze_sentiment(text) > 0
     text2 = "Time to sell and go short, very bearish"
     assert analyze_sentiment(text2) < 0
+    text3 = "Lasst uns jetzt kaufen, das ist sehr bullisch"
+    assert analyze_sentiment(text3) > 0
+    text4 = "Vielleicht sollten wir verkaufen, es wirkt bärisch"
+    assert analyze_sentiment(text4) < 0
 
 
 def test_aggregate_and_recommendation():
     data = {
-        "NVDA": [{"text": "buy the dip"}, {"text": "bullish"}],
-        "AMZN": [{"text": "sell now"}]
+        "NVDA": [{"text": "buy the dip"}, {"text": "bullish"}, {"text": "kaufen"}],
+        "AMZN": [{"text": "sell now"}, {"text": "verkaufen"}]
     }
     scores = aggregate_sentiment_by_ticker(data)
     assert scores["NVDA"] > 0

--- a/wallenstein/sentiment.py
+++ b/wallenstein/sentiment.py
@@ -1,4 +1,7 @@
-"""Utility functions for simplistic sentiment analysis."""
+"""Utility functions for simplistic sentiment analysis.
+
+The keyword map supports both common English and German trading slang
+allowing rudimentary multilingual sentiment detection."""
 
 from __future__ import annotations
 
@@ -20,12 +23,16 @@ KEYWORD_SCORES: Dict[str, int] = {
     "bull": 1,
     "bullish": 1,
     "buy": 1,
+    "kaufen": 1,
+    "bullisch": 1,
     # negative
     "short": -1,
     "put": -1,
     "bear": -1,
     "bearish": -1,
     "sell": -1,
+    "verkaufen": -1,
+    "bärisch": -1,
 }
 
 


### PR DESCRIPTION
## Summary
- expand sentiment keyword map with German equivalents
- test German keywords and ensure aggregator handles them
- document multilingual keyword support in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa15e1be5083258109de520f19ba5b