### PR TITLE
Normalize dates before merging sentiment and price data

### DIFF
--- a/main.py
+++ b/main.py
@@ -114,6 +114,7 @@ def main() -> int:
             df_sent = sentiment_frames.get(
                 ticker, pd.DataFrame(columns=["date", "sentiment"])
             )
+            df_sent["date"] = pd.to_datetime(df_sent["date"]).dt.normalize()
             df_stock = pd.merge(df_price, df_sent, on="date", how="left")
             acc = train_per_stock(df_stock)
             if acc is not None:


### PR DESCRIPTION
## Summary
- Normalize post timestamps with `dt.normalize()`
- Ensure both price and sentiment dates are normalized before merge to avoid dtype warnings

## Testing
- `pytest -q`
- `python - <<'PY'
import pandas as pd, warnings

df_price = pd.DataFrame({'date': ['2023-01-01', '2023-01-02'], 'close': [10, 20]})
df_price['date'] = pd.to_datetime(df_price['date']).dt.normalize()

df_sent = pd.DataFrame({'date': ['2023-01-01', '2023-01-03'], 'sentiment': [0.1, 0.2]})
df_sent['date'] = pd.to_datetime(df_sent['date']).dt.normalize()

with warnings.catch_warnings(record=True) as w:
    warnings.simplefilter('always')
    df_stock = pd.merge(df_price, df_sent, on='date', how='left')
    print(df_stock)
    print('warnings:', len(w))
    for warn in w:
        print('warning:', warn.message)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68aa15da588083258b378dbdbde5ed93