### PR TITLE
Handle negations and intensifiers in sentiment analysis

### DIFF
--- a/tests/test_sentiment.py
+++ b/tests/test_sentiment.py
@@ -29,3 +29,8 @@ def test_aggregate_and_recommendation():
     assert derive_recommendation(scores["NVDA"]) == "Buy"
     assert derive_recommendation(scores["AMZN"]) == "Sell"
     assert derive_recommendation(0.0) == "Hold"
+
+
+def test_intensity_and_negation():
+    assert analyze_sentiment("This is a strong buy signal") == 2
+    assert analyze_sentiment("Bitte nicht kaufen") < 0


### PR DESCRIPTION
## Summary
- expand keyword map with intensity and negation support
- add `apply_negation` to flip sentiment on phrases like "nicht kaufen"
- weight intensifiers such as "strong" when scoring
- add test covering negation and intensity

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aa183f2b68832584063d9ca4c72753