### PR TITLE
Add K-Fold option and rolling features to model

### DIFF
--- a/main.py
+++ b/main.py
@@ -116,9 +116,9 @@ def main() -> int:
             )
             df_sent["date"] = pd.to_datetime(df_sent["date"]).dt.normalize()
             df_stock = pd.merge(df_price, df_sent, on="date", how="left")
-            acc = train_per_stock(df_stock)
+            acc, f1 = train_per_stock(df_stock)
             if acc is not None:
-                log.info(f"{ticker}: Modell-Accuracy {acc:.2%}")
+                log.info(f"{ticker}: Modell-Accuracy {acc:.2%} | F1 {f1:.2f}")
             else:
                 log.info(f"{ticker}: Zu wenige Daten für Modelltraining")
         except Exception as e:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -17,9 +17,12 @@ def test_train_per_stock_basic():
         "close": [1, 2, 1.5, 1.8, 2.2, 2.1, 2.3, 2.5, 2.4, 2.6],
         "sentiment": [0.1, -0.2, 0.0, 0.3, 0.5, -0.1, 0.2, 0.1, -0.2, 0.3],
     })
-    acc = train_per_stock(df)
+    acc, f1 = train_per_stock(df, use_kfold=True, n_splits=3)
+    print(f"Accuracy: {acc:.3f}, F1: {f1:.3f}")
     assert acc is not None
+    assert f1 is not None
     assert 0.0 <= acc <= 1.0
+    assert 0.0 <= f1 <= 1.0
 
 
 def test_train_per_stock_insufficient_classes():
@@ -29,5 +32,5 @@ def test_train_per_stock_insufficient_classes():
         "close": [1, 1, 1, 1, 1],  # no variation -> only one class
         "sentiment": [0, 0, 0, 0, 0],
     })
-    acc = train_per_stock(df)
-    assert acc is None
+    acc, f1 = train_per_stock(df)
+    assert acc is None and f1 is None

--- a/wallenstein/models.py
+++ b/wallenstein/models.py
@@ -1,10 +1,20 @@
+import logging
+from typing import Optional, Tuple
+
+import numpy as np
 import pandas as pd
 from sklearn.linear_model import LogisticRegression
-from sklearn.metrics import accuracy_score
-from typing import Optional
+from sklearn.metrics import accuracy_score, f1_score
+from sklearn.model_selection import KFold
+
+log = logging.getLogger(__name__)
 
 
-def train_per_stock(df_stock: pd.DataFrame) -> Optional[float]:
+def train_per_stock(
+    df_stock: pd.DataFrame,
+    use_kfold: bool = False,
+    n_splits: int = 5,
+) -> Optional[Tuple[float, float]]:
     """Train a simple LogisticRegression on lagged close and sentiment data.
 
     Parameters
@@ -17,13 +27,14 @@ def train_per_stock(df_stock: pd.DataFrame) -> Optional[float]:
 
     Returns
     -------
-    Optional[float]
-        Accuracy of the model on the hold‑out test set. ``None`` is returned if
-        there are insufficient samples or only one class in the training data.
+    Optional[Tuple[float, float]]
+        Tuple of (accuracy, F1-score) of the model on the evaluation set. ``None``
+        is returned for both metrics if there are insufficient samples or only
+        one class in the training data.
     """
 
     if df_stock.empty:
-        return None
+        return None, None
 
     df = df_stock.sort_values("date").copy()
     # Convert sentiment to numeric and replace invalid entries with 0
@@ -32,33 +43,78 @@ def train_per_stock(df_stock: pd.DataFrame) -> Optional[float]:
     # Lagged features
     df["Close_lag1"] = df["close"].shift(1)
     df["Sentiment_lag1"] = df["sentiment"].shift(1)
+
+    # Rolling features for close and sentiment
+    df["Close_MA3"] = df["close"].rolling(window=3).mean().shift(1)
+    df["Close_STD3"] = df["close"].rolling(window=3).std().shift(1)
+    df["Sentiment_MA3"] = df["sentiment"].rolling(window=3).mean().shift(1)
+    df["Sentiment_STD3"] = df["sentiment"].rolling(window=3).std().shift(1)
+
     df["y"] = (df["close"] > df["Close_lag1"]).astype(int)
     df.dropna(inplace=True)
 
     if len(df) < 2:
-        return None
+        return None, None
 
-    train_size = max(int(len(df) * 0.8), 1)
-    df_train = df.iloc[:train_size]
-    df_test = df.iloc[train_size:]
+    features = [
+        "Close_lag1",
+        "Sentiment_lag1",
+        "Close_MA3",
+        "Close_STD3",
+        "Sentiment_MA3",
+        "Sentiment_STD3",
+    ]
 
-    X_train = df_train[["Close_lag1", "Sentiment_lag1"]]
-    y_train = df_train["y"]
-
-    # Need at least two classes to train logistic regression
-    if y_train.nunique() < 2:
-        return None
+    X = df[features]
+    y = df["y"]
 
     model = LogisticRegression()
-    model.fit(X_train, y_train)
 
-    if df_test.empty:
-        y_pred = model.predict(X_train)
-        accuracy = accuracy_score(y_train, y_pred)
+    if use_kfold and len(df) >= n_splits:
+        kf = KFold(n_splits=n_splits)
+        accuracies = []
+        f1_scores = []
+        for train_idx, test_idx in kf.split(X):
+            X_train, X_test = X.iloc[train_idx], X.iloc[test_idx]
+            y_train, y_test = y.iloc[train_idx], y.iloc[test_idx]
+
+            if y_train.nunique() < 2 or y_test.nunique() < 2:
+                continue
+
+            model.fit(X_train, y_train)
+            y_pred = model.predict(X_test)
+            accuracies.append(accuracy_score(y_test, y_pred))
+            f1_scores.append(f1_score(y_test, y_pred, zero_division=0))
+
+        if not accuracies:
+            return None, None
+
+        accuracy = float(np.mean(accuracies))
+        f1 = float(np.mean(f1_scores))
     else:
-        X_test = df_test[["Close_lag1", "Sentiment_lag1"]]
-        y_test = df_test["y"]
-        y_pred = model.predict(X_test)
-        accuracy = accuracy_score(y_test, y_pred)
+        train_size = max(int(len(df) * 0.8), 1)
+        df_train = df.iloc[:train_size]
+        df_test = df.iloc[train_size:]
 
-    return float(accuracy)
+        X_train = df_train[features]
+        y_train = df_train["y"]
+
+        # Need at least two classes to train logistic regression
+        if y_train.nunique() < 2:
+            return None, None
+
+        model.fit(X_train, y_train)
+
+        if df_test.empty:
+            y_pred = model.predict(X_train)
+            accuracy = accuracy_score(y_train, y_pred)
+            f1 = f1_score(y_train, y_pred, zero_division=0)
+        else:
+            X_test = df_test[features]
+            y_test = df_test["y"]
+            y_pred = model.predict(X_test)
+            accuracy = accuracy_score(y_test, y_pred)
+            f1 = f1_score(y_test, y_pred, zero_division=0)
+
+    log.info(f"Model accuracy: {accuracy:.4f}, F1: {f1:.4f}")
+    return float(accuracy), float(f1)


### PR DESCRIPTION
## Summary
- integrate optional K-Fold cross-validation into `train_per_stock`
- add rolling mean and std features for price and sentiment
- log and test accuracy and F1-score

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa1e706ad88325910fd0c0f8186042