### PR TITLE
Improve negation handling across filler tokens

### DIFF
--- a/tests/test_sentiment.py
+++ b/tests/test_sentiment.py
@@ -34,3 +34,8 @@ def test_aggregate_and_recommendation():
 def test_intensity_and_negation():
     assert analyze_sentiment("This is a strong buy signal") == 2
     assert analyze_sentiment("Bitte nicht kaufen") < 0
+
+
+def test_negation_with_filler_tokens():
+    assert analyze_sentiment("nicht so bullish") < 0
+    assert analyze_sentiment("kein kauf heute") < 0


### PR DESCRIPTION
## Summary
- Expand keyword list to recognise German noun "kauf"
- Allow negation handling to search up to two tokens ahead, skipping filler words
- Add tests for phrases like "nicht so bullish" and "kein kauf heute"

## Testing
- `pytest tests/test_sentiment.py::test_negation_with_filler_tokens -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa1e6d91908325a8fc686dca1f50df