### PR TITLE
Add sentiment evaluation dataset and script

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ python main.py
    └─ sentiment.py
 ```
 
+## Sentiment evaluation
+
+The repository ships with a tiny labelled dataset in
+`data/sentiment_labels.csv`. To compare the keyword based sentiment analysis
+with a transformer model, run:
+
+```bash
+python scripts/evaluate_sentiment.py
+```
+
+The script prints accuracy, precision and recall for both approaches. Use the
+`SENTIMENT_BACKEND` environment variable to select the BERT model (default
+`finbert`).
+
 ### Notes
 - If you already have your own `stock_data.py`, you can keep it. This repo’s version is robust and compatible with `update_prices(TICKERS)` signature.
 - GitHub push safe: no secrets, data folder is empty (with `.gitkeep`).

--- a/data/sentiment_labels.csv
+++ b/data/sentiment_labels.csv
@@ -1,0 +1,11 @@
+text,label
+"Stocks are going up and I'm excited",positive
+"I hate losing money in the market",negative
+"Buy the dip now",positive
+"This company will crash soon",negative
+"I am very happy with the profits",positive
+"Sell everything it's over",negative
+"Bullish on tech stocks",positive
+"This is a terrible investment",negative
+"Strong buy recommendation",positive
+"Not a good time to invest",negative

--- a/scripts/evaluate_sentiment.py
+++ b/scripts/evaluate_sentiment.py
@@ -1,0 +1,62 @@
+"""Evaluate keyword and BERT sentiment analysers on a labelled dataset."""
+
+import os
+import sys
+
+import pandas as pd
+from sklearn.metrics import accuracy_score, precision_score, recall_score
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from wallenstein.sentiment import analyze_sentiment, BertSentiment
+
+
+def keyword_prediction(texts):
+    """Return ``positive``/``negative`` predictions using keyword analysis."""
+    predictions = []
+    for text in texts:
+        score = analyze_sentiment(text)
+        predictions.append("positive" if score > 0 else "negative")
+    return predictions
+
+
+def bert_prediction(texts):  # pragma: no cover - downloads model
+    """Return ``positive``/``negative`` predictions using a BERT model."""
+    analyzer = BertSentiment()
+    predictions = []
+    for text in texts:
+        result = analyzer(text)[0]
+        label = result["label"].lower()
+        predictions.append("positive" if label.startswith("pos") else "negative")
+    return predictions
+
+
+def evaluate(true, pred):
+    return {
+        "accuracy": accuracy_score(true, pred),
+        "precision": precision_score(true, pred, pos_label="positive"),
+        "recall": recall_score(true, pred, pos_label="positive"),
+    }
+
+
+def main():
+    data = pd.read_csv("data/sentiment_labels.csv")
+    texts = data["text"].tolist()
+    labels = data["label"].tolist()
+
+    kw_pred = keyword_prediction(texts)
+    bert_pred = bert_prediction(texts)
+
+    kw_metrics = evaluate(labels, kw_pred)
+    bert_metrics = evaluate(labels, bert_pred)
+
+    print("Keyword-based approach:")
+    for k, v in kw_metrics.items():
+        print(f"{k.capitalize()}: {v:.2f}")
+
+    print("\nBERT-based approach:")
+    for k, v in bert_metrics.items():
+        print(f"{k.capitalize()}: {v:.2f}")
+
+
+if __name__ == "__main__":  # pragma: no cover - simple script
+    main()


### PR DESCRIPTION
## Summary
- add small labelled dataset for sentiment evaluation
- script to compare keyword heuristics vs BERT-based sentiment and report metrics
- document sentiment evaluation workflow in README

## Testing
- `pytest -q`
- `python scripts/evaluate_sentiment.py` *(fails: ProxyError: Unable to connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1e732a1c8325868f43d1e8b99aeb