### PR TITLE
Log insert count for Reddit posts

### DIFF
--- a/wallenstein/reddit_scraper.py
+++ b/wallenstein/reddit_scraper.py
@@ -241,10 +241,12 @@ def update_reddit_data(
                 "CREATE UNIQUE INDEX IF NOT EXISTS reddit_posts_id_idx ON reddit_posts(id)"
             )
             con.register("df_all", df_all)
-            con.execute(
+            cur = con.execute(
                 "INSERT INTO reddit_posts SELECT * FROM df_all ON CONFLICT(id) DO NOTHING"
             )
-        log.info(f"Wrote {len(df_all)} posts to reddit_posts")
+        log.info(
+            f"Wrote {len(df_all)} posts to reddit_posts ({cur.rowcount} new)"
+        )
 
     # Alte Einträge entfernen
     purge_old_posts()


### PR DESCRIPTION
## Summary
- report actual number of inserted Reddit posts using cursor.rowcount
- include both attempted and new post totals in log message

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa245af15c8325b1741ffd01f87dd4