### PR TITLE
Add debug logging for ticker matches and configurable log level

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,7 +13,11 @@ if not env_loaded:
     load_dotenv(dotenv_path=alt_path, override=True)
 
 # --- Logging ---
-logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+LOG_LEVEL = os.getenv("WALLENSTEIN_LOG_LEVEL", "INFO").upper()
+logging.basicConfig(
+    level=getattr(logging, LOG_LEVEL, logging.INFO),
+    format="%(asctime)s %(levelname)s %(message)s",
+)
 log = logging.getLogger("wallenstein")
 
 try:

--- a/wallenstein/reddit_scraper.py
+++ b/wallenstein/reddit_scraper.py
@@ -22,6 +22,8 @@ except Exception:  # pragma: no cover - not critical if missing
 from . import config
 
 log = logging.getLogger("wallenstein.reddit")
+if os.getenv("WALLENSTEIN_LOG_LEVEL", "").upper() == "DEBUG":
+    log.setLevel(logging.DEBUG)
 
 # Gemeinsamer DB-Pfad (ENV erlaubt Override, sonst Default)
 DB_PATH = os.getenv("WALLENSTEIN_DB_PATH", "wallenstein.duckdb")
@@ -269,5 +271,6 @@ def update_reddit_data(
             # leichte Obergrenze pro Ticker (Performance)
             if len(bucket) >= 100:
                 break
+        log.debug(f"{tkr}: {len(bucket)} matched posts")
         out[tkr] = bucket
     return out


### PR DESCRIPTION
## Summary
- Log number of Reddit posts matched for each ticker in `update_reddit_data`
- Allow log level configuration via `WALLENSTEIN_LOG_LEVEL` environment variable

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa245bd5d48325a9a06e0432cdac32