### PR TITLE
Default to BERT sentiment when available and extend keyword map

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ python main.py
 - `WALLENSTEIN_DB_PATH` = path to DuckDB (default `data/wallenstein.duckdb`)
 - `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID` (optional alerts)
 - `REDDIT_CLIENT_ID`, `REDDIT_CLIENT_SECRET`, `REDDIT_USER_AGENT` (optional for true Reddit scraping)
+- `USE_BERT_SENTIMENT` = choose sentiment backend. When unset the app uses a
+  BERT model if the `transformers` package is available, otherwise a lightweight
+  keyword approach. Set to `1`/`true` to force BERT or `0`/`false` to force the
+  keyword method.
 
 ### Structure
 ```
@@ -63,7 +67,9 @@ python scripts/evaluate_sentiment.py
 
 The script prints accuracy, precision and recall for both approaches. Use the
 `SENTIMENT_BACKEND` environment variable to select the BERT model (default
-`finbert`).
+`finbert`). Sentiment analysis uses a BERT model automatically when
+`transformers` is installed. Set `USE_BERT_SENTIMENT=0` to force the lightweight
+keyword approach or `USE_BERT_SENTIMENT=1` to explicitly enable the BERT path.
 
 
 ### Notes

--- a/tests/test_sentiment.py
+++ b/tests/test_sentiment.py
@@ -2,6 +2,8 @@ import sys
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
@@ -13,6 +15,13 @@ from wallenstein.sentiment import (
     aggregate_sentiment_by_ticker,
     derive_recommendation,
 )
+
+
+@pytest.fixture(autouse=True)
+def _disable_bert(monkeypatch):
+    """Use keyword sentiment by default for tests."""
+
+    monkeypatch.setenv("USE_BERT_SENTIMENT", "0")
 
 def test_analyze_sentiment_keywords():
     text = "I'm going long and want to buy more calls, not sell"


### PR DESCRIPTION
## Summary
- Default to BERT-based sentiment analysis when `transformers` is installed and log a hint when falling back to keyword analysis
- Expand keyword sentiment map with common trading slang such as "dip", "moon", "dump" and "pump"
- Document `USE_BERT_SENTIMENT` environment variable and update tests to reflect new default

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa245cb8888325bcaa07db6afcab9c