### PR TITLE
feat: make comment fetching optional

### DIFF
--- a/tests/test_reddit_scraper.py
+++ b/tests/test_reddit_scraper.py
@@ -102,7 +102,7 @@ def test_fetches_hot_and_new_posts_with_comments(monkeypatch):
 
     monkeypatch.setattr(reddit_scraper.praw, "Reddit", lambda **k: FakeReddit())
 
-    df = reddit_scraper.fetch_reddit_posts("dummy", limit=1)
+    df = reddit_scraper.fetch_reddit_posts("dummy", limit=1, include_comments=True)
     ids = set(df["id"]) if not df.empty else set()
     assert ids == {"h1", "n1", "h1_c1"}
 


### PR DESCRIPTION
## Summary
- allow toggling comment scraping via `include_comments` in `fetch_reddit_posts`
- thread comment inclusion through `update_reddit_data`
- adapt tests to new API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab0f834a188325b9bd12cbbe802df1