### PR TITLE
Add batch sentiment analysis function and apply in main

### DIFF
--- a/main.py
+++ b/main.py
@@ -52,7 +52,7 @@ TELEGRAM_CHAT_ID = os.getenv("TELEGRAM_CHAT_ID", "").strip()
 # --- Projekt‑Module ---
 from wallenstein.stock_data import update_prices, update_fx_rates
 from wallenstein.db_utils import ensure_prices_view, get_latest_prices
-from wallenstein.sentiment import analyze_sentiment, derive_recommendation
+from wallenstein.sentiment import analyze_sentiment_batch, derive_recommendation
 from wallenstein.models import train_per_stock
 
 
@@ -96,7 +96,7 @@ def main() -> int:
         texts = list(texts)
         if texts:
             df_posts = pd.DataFrame(texts)
-            df_posts["sentiment"] = df_posts["text"].apply(analyze_sentiment)
+            df_posts["sentiment"] = analyze_sentiment_batch(df_posts["text"].tolist())
             df_posts["date"] = pd.to_datetime(df_posts["created_utc"]).dt.normalize()
             sentiment_frames[ticker] = (
                 df_posts.groupby("date")["sentiment"].mean().reset_index()

--- a/tests/test_sentiment.py
+++ b/tests/test_sentiment.py
@@ -12,6 +12,7 @@ import wallenstein.sentiment as sentiment
 from wallenstein.sentiment import (
     analyze_sentiment,
     analyze_sentiment_bert,
+    analyze_sentiment_batch,
     aggregate_sentiment_by_ticker,
     derive_recommendation,
 )
@@ -76,4 +77,11 @@ def test_env_switches_to_bert(monkeypatch):
 def test_negation_with_filler_tokens():
     assert analyze_sentiment("nicht so bullish") < 0
     assert analyze_sentiment("kein kauf heute") < 0
+
+
+def test_analyze_sentiment_batch_keyword():
+    texts = ["bullish", "verkaufen"]
+    scores = analyze_sentiment_batch(texts)
+    assert scores[0] > 0
+    assert scores[1] < 0
 


### PR DESCRIPTION
## Summary
- add `analyze_sentiment_batch` to process lists of texts with one BERT pipeline call and keyword fallback
- update main pipeline to use the batch sentiment analyser
- extend sentiment tests to cover batch analysis

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab0f8affac83258ddd6c9318123aae