### PR TITLE
feat: allow dynamic ticker alias loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,23 @@ list of additional names that should be recognised in Reddit posts:
 `reddit_scraper` loads this file on startup and merges it with its built-in
 defaults. If the file is missing, the internal map is used unchanged.
 
+Aliases can also be supplied dynamically when calling
+``update_reddit_data``. Pass either a path to a JSON/YAML file via
+``aliases_path`` or an in-memory mapping via ``aliases``:
+
+```python
+from wallenstein import reddit_scraper
+
+# reload aliases from a custom file before each update
+reddit_scraper.update_reddit_data(["NVDA"], aliases_path="my_aliases.json")
+
+# or merge a dict directly
+reddit_scraper.update_reddit_data(["NVDA"], aliases={"NVDA": ["nvidia corp"]})
+```
+
+The file specified by ``aliases_path`` is read on every call so changes are
+picked up immediately.
+
 ## Sentiment evaluation
 
 The repository ships with a tiny labelled dataset in

--- a/tests/test_reddit_scraper.py
+++ b/tests/test_reddit_scraper.py
@@ -106,3 +106,56 @@ def test_fetches_hot_and_new_posts_with_comments(monkeypatch):
     ids = set(df["id"]) if not df.empty else set()
     assert ids == {"h1", "n1", "h1_c1"}
 
+
+def test_aliases_passed_as_dict(monkeypatch):
+    """Custom alias mapping can be merged directly."""
+    now = datetime.now(timezone.utc)
+    df = pd.DataFrame([
+        {"id": "1", "title": "", "created_utc": now, "text": "Some Corp news"}
+    ])
+
+    monkeypatch.setattr(reddit_scraper, "fetch_reddit_posts", lambda *a, **k: df)
+    monkeypatch.setattr(reddit_scraper, "_load_posts_from_db", lambda: df)
+    monkeypatch.setattr(reddit_scraper, "purge_old_posts", lambda: None)
+
+    aliases = {"ABC": ["some corp"]}
+    out = reddit_scraper.update_reddit_data(
+        ["ABC"], subreddits=None, aliases=aliases
+    )
+    assert len(out["ABC"]) == 1
+    assert "some corp" in out["ABC"][0]["text"].lower()
+
+
+def test_alias_file_reloaded_each_call(monkeypatch, tmp_path):
+    """Alias file is read for every update."""
+    import json
+
+    now = datetime.now(timezone.utc)
+    df1 = pd.DataFrame([
+        {"id": "1", "title": "", "created_utc": now, "text": "Corp1 rises"}
+    ])
+    df2 = pd.DataFrame([
+        {"id": "2", "title": "", "created_utc": now, "text": "Corp2 rises"}
+    ])
+
+    alias_file = tmp_path / "aliases.json"
+    alias_file.write_text(json.dumps({"ZZZ": ["corp1"]}))
+
+    empty = pd.DataFrame(columns=["id", "title", "created_utc", "text"])
+    monkeypatch.setattr(reddit_scraper, "fetch_reddit_posts", lambda *a, **k: empty)
+    monkeypatch.setattr(reddit_scraper, "purge_old_posts", lambda: None)
+    monkeypatch.setattr(reddit_scraper, "_load_posts_from_db", lambda: df1)
+
+    out1 = reddit_scraper.update_reddit_data(
+        ["ZZZ"], subreddits=None, aliases_path=alias_file
+    )
+    assert out1["ZZZ"] and "corp1" in out1["ZZZ"][0]["text"].lower()
+
+    alias_file.write_text(json.dumps({"ZZZ": ["corp2"]}))
+    monkeypatch.setattr(reddit_scraper, "_load_posts_from_db", lambda: df2)
+
+    out2 = reddit_scraper.update_reddit_data(
+        ["ZZZ"], subreddits=None, aliases_path=alias_file
+    )
+    assert out2["ZZZ"] and "corp2" in out2["ZZZ"][0]["text"].lower()
+

--- a/wallenstein/reddit_scraper.py
+++ b/wallenstein/reddit_scraper.py
@@ -47,27 +47,53 @@ TICKER_NAME_MAP: Dict[str, List[str]] = {
 }
 
 
-def _load_aliases_from_file() -> None:
-    """Merge additional ticker aliases from JSON/YAML file."""
+def _load_aliases_from_file(
+    path: str | Path | None = None, aliases: Dict[str, List[str]] | None = None
+) -> None:
+    """Merge additional ticker aliases from a dict or JSON/YAML file.
 
+    Parameters
+    ----------
+    path:
+        Optional file path pointing to a JSON or YAML file containing alias
+        mappings. When provided the file is parsed on every call.
+    aliases:
+        Optional in-memory mapping ``{"TICKER": ["alias1", ...]}`` that is
+        merged directly into :data:`TICKER_NAME_MAP`.
+    """
+
+    # 1) Merge explicit alias mapping first
+    if aliases:
+        for tkr, names in aliases.items():
+            if not isinstance(names, list):
+                continue
+            bucket = TICKER_NAME_MAP.setdefault(tkr.upper(), [])
+            for name in names:
+                name = str(name).lower()
+                if name not in bucket:
+                    bucket.append(name)
+
+    # 2) Determine candidate file paths
     root = Path(__file__).resolve().parents[1]
-    candidates = [
+    candidates = [Path(path)] if path else [
         root / "data" / "ticker_aliases.json",
         root / "data" / "ticker_aliases.yaml",
         root / "data" / "ticker_aliases.yml",
     ]
 
-    for path in candidates:
-        if not path.exists():
+    for candidate in candidates:
+        if not candidate.exists():
             continue
         try:
-            with path.open("r", encoding="utf-8") as fh:
-                if path.suffix == ".json":
+            with candidate.open("r", encoding="utf-8") as fh:
+                if candidate.suffix == ".json":
                     data = json.load(fh)
-                elif path.suffix in {".yaml", ".yml"} and yaml:
+                elif candidate.suffix in {".yaml", ".yml"} and yaml:
                     data = yaml.safe_load(fh)
                 else:
-                    log.warning("Unsupported ticker alias file format: %s", path)
+                    log.warning(
+                        "Unsupported ticker alias file format: %s", candidate
+                    )
                     data = {}
 
             for tkr, names in data.items():
@@ -79,7 +105,9 @@ def _load_aliases_from_file() -> None:
                     if name not in bucket:
                         bucket.append(name)
         except Exception as exc:  # pragma: no cover - defensive
-            log.warning("Could not load ticker aliases from %s: %s", path, exc)
+            log.warning(
+                "Could not load ticker aliases from %s: %s", candidate, exc
+            )
         break  # use first existing file only
 
 
@@ -202,16 +230,35 @@ def update_reddit_data(
     subreddits: List[str] | None = None,
     limit_per_sub: int = 50,
     include_comments: bool = False,
+    aliases_path: str | Path | None = None,
+    aliases: Dict[str, List[str]] | None = None,
 ) -> Dict[str, List[dict]]:
     """Scrape, persist and organise Reddit posts.
 
-    Posts from every subreddit are combined into a single DataFrame before new
-    entries are merged into the ``reddit_posts`` table.  Afterwards, rows older
-    than ``DATA_RETENTION_DAYS`` are purged to keep the table small.  Returns a
-    mapping such as
-    ``{"NVDA": [{"created_utc": <timestamp>, "text": "..."}, ...]}`` where each
-    entry contains the post timestamp and text.
+    Parameters
+    ----------
+    tickers:
+        Symbols that should be matched in the collected posts.
+    subreddits:
+        Optional list of subreddits. Falls back to a small default set.
+    limit_per_sub:
+        Number of posts to fetch per subreddit.
+    include_comments:
+        Whether to also scan a few top-level comments.
+    aliases_path / aliases:
+        Extra ticker alias definitions.  ``aliases_path`` points to a JSON/YAML
+        file that is reloaded on every call. ``aliases`` is an in-memory mapping
+        in the same format.  Both are merged into
+        :data:`TICKER_NAME_MAP` before processing.
+
+    Returns
+    -------
+    dict
+        Mapping such as ``{"NVDA": [{"created_utc": <timestamp>, "text": "..."},
+        ...]}`` where each entry contains the post timestamp and text.
     """
+    # Refresh alias data if provided
+    _load_aliases_from_file(aliases_path, aliases)
     if not subreddits:
         subreddits = ["wallstreetbets", "wallstreetbetsGer", "mauerstrassenwetten"]
 


### PR DESCRIPTION
## Summary
- allow passing alias file paths or dicts to `_load_aliases_from_file` and `update_reddit_data`
- document runtime alias loading and usage
- test alias merging via dict and file reload

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab1443be348325b070f1f4bd93439d