### PR TITLE
Add Telegram bot handler for ticker commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Broker-target support is temporarily disabled pending a new data provider.
 pip install -r requirements.txt
 cp .env.example .env   # and fill values
 python main.py
+python telegram_bot.py  # optional: interactive Telegram bot
 ```
 
 ### ENV (via `.env` or system env)
@@ -30,6 +31,7 @@ python main.py
 ├─ requirements.txt
 ├─ .env.example
 ├─ data/                  # DuckDB lives here
+├─ telegram_bot.py       # listens for `!TICKER` messages on Telegram
 └─ wallenstein/
    ├─ __init__.py
    ├─ stock_data.py
@@ -71,6 +73,19 @@ reddit_scraper.update_reddit_data(["NVDA"], aliases={"NVDA": ["nvidia corp"]})
 
 The file specified by ``aliases_path`` is read on every call so changes are
 picked up immediately.
+
+## Telegram Bot
+
+Start a small bot that reacts to messages like ``!NVDA`` and returns the number
+of matching Reddit posts:
+
+```bash
+python telegram_bot.py
+```
+
+The bot uses ``reddit_scraper.update_reddit_data`` internally.  Set
+``TELEGRAM_BOT_TOKEN`` (and optionally ``TELEGRAM_CHAT_ID`` for the broadcast
+helper ``notify_telegram``) in your environment or ``.env`` file.
 
 ## Sentiment evaluation
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ scikit-learn
 pandas-datareader
 transformers
 torch
+python-telegram-bot

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -1,0 +1,43 @@
+import logging
+
+from telegram import Update
+from telegram.ext import ApplicationBuilder, ContextTypes, MessageHandler, filters
+
+from wallenstein.reddit_scraper import update_reddit_data
+from wallenstein.notify import notify_telegram
+from wallenstein import config
+
+log = logging.getLogger(__name__)
+
+async def handle_ticker(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Parse messages like ``!NVDA`` and update Reddit data for the ticker."""
+    if not update.message or not update.message.text:
+        return
+    text = update.message.text.strip()
+    if not text.startswith("!"):
+        return
+    ticker = text[1:].split()[0].upper()
+    log.info("Telegram request for %s", ticker)
+    try:
+        data = update_reddit_data([ticker])
+    except Exception as exc:  # pragma: no cover - network failures
+        await update.message.reply_text(f"Fehler beim Abrufen von {ticker}: {exc}")
+        return
+    posts = data.get(ticker, [])
+    msg = f"{ticker}: {len(posts)} Reddit posts gefunden."
+    await update.message.reply_text(msg)
+    try:
+        notify_telegram(msg)
+    except Exception:
+        # ignore optional broadcast errors
+        pass
+
+def main() -> None:
+    """Start the Telegram bot and listen for ticker commands."""
+    app = ApplicationBuilder().token(config.TELEGRAM_BOT_TOKEN).build()
+    app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_ticker))
+    app.run_polling()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -1,0 +1,29 @@
+import asyncio
+import types
+
+from telegram_bot import handle_ticker
+
+
+class DummyMessage:
+    def __init__(self, text: str):
+        self.text = text
+        self.replies = []
+
+    async def reply_text(self, text: str) -> None:
+        self.replies.append(text)
+
+
+def test_handle_ticker(monkeypatch):
+    called = {}
+
+    def fake_update(tickers):
+        called['tickers'] = tickers
+        return {tickers[0]: [1, 2]}
+
+    monkeypatch.setattr('telegram_bot.update_reddit_data', fake_update)
+    monkeypatch.setattr('telegram_bot.notify_telegram', lambda msg: None)
+    update = types.SimpleNamespace(message=DummyMessage('!nvda'))
+    context = types.SimpleNamespace()
+    asyncio.run(handle_ticker(update, context))
+    assert called['tickers'] == ['NVDA']
+    assert update.message.replies == ['NVDA: 2 Reddit posts gefunden.']


### PR DESCRIPTION
## Summary
- add simple `telegram_bot.py` that listens for `!TICKER` messages and updates Reddit data
- document bot usage in the README and include `python-telegram-bot` dependency
- cover handler logic with a small unit test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab17b66cdc8325969ee05cebcff487