### PR TITLE
refactor: extract overview helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Broker-target support is temporarily disabled pending a new data provider.
 pip install -r requirements.txt
 cp .env.example .env   # and fill values
 python main.py
-python telegram_bot.py  # optional: interactive Telegram bot
+python telegram_bot.py  # optional: interactive Telegram bot; use !<ticker>
 ```
 
 ### ENV (via `.env` or system env)
@@ -76,16 +76,18 @@ picked up immediately.
 
 ## Telegram Bot
 
-Start a small bot that reacts to messages like ``!NVDA`` and returns the number
-of matching Reddit posts:
+Start a small bot that reacts to messages like ``!NVDA`` and returns a price
+and sentiment overview for the requested ticker:
 
 ```bash
 python telegram_bot.py
 ```
 
-The bot uses ``reddit_scraper.update_reddit_data`` internally.  Set
-``TELEGRAM_BOT_TOKEN`` (and optionally ``TELEGRAM_CHAT_ID`` for the broadcast
-helper ``notify_telegram``) in your environment or ``.env`` file.
+In Telegram chat send ``!<ticker>`` to get the latest Wallenstein overview.
+`main.py` continues to run independently (manually or via GitHub Actions) to
+update the data. Configure ``TELEGRAM_BOT_TOKEN`` (and optionally
+``TELEGRAM_CHAT_ID`` for the broadcast helper ``notify_telegram``) in your
+environment or ``.env`` file.
 
 ## Sentiment evaluation
 

--- a/main.py
+++ b/main.py
@@ -52,7 +52,8 @@ TELEGRAM_CHAT_ID = os.getenv("TELEGRAM_CHAT_ID", "").strip()
 # --- Projekt‑Module ---
 from wallenstein.stock_data import update_prices, update_fx_rates
 from wallenstein.db_utils import ensure_prices_view, get_latest_prices
-from wallenstein.sentiment import analyze_sentiment_batch, derive_recommendation
+from wallenstein.sentiment import analyze_sentiment_batch
+from wallenstein.overview import generate_overview
 from wallenstein.models import train_per_stock
 
 
@@ -128,22 +129,7 @@ def main() -> int:
         except Exception as e:
             log.warning(f"{ticker}: Modelltraining fehlgeschlagen: {e}")
 
-    price_lines = []
-    sentiment_lines = []
-    for t in TICKERS:
-        price = prices_usd.get(t)
-        if price is not None:
-            price_lines.append(f"{t}: {price:.2f} USD")
-        else:
-            price_lines.append(f"{t}: n/a")
-
-        sent = sentiments.get(t, 0.0)
-        rec = derive_recommendation(sent)
-        sentiment_lines.append(f"{t}: Sentiment {sent:+.2f} | {rec}")
-
-    notify_telegram(
-        "📊 Wallenstein Übersicht\n" + "\n".join(price_lines + sentiment_lines)
-    )
+    notify_telegram(generate_overview(TICKERS))
 
     log.info(f"🏁 Fertig in {time.time() - t0:.1f}s")
     return 0

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -16,14 +16,13 @@ class DummyMessage:
 def test_handle_ticker(monkeypatch):
     called = {}
 
-    def fake_update(tickers):
+    def fake_overview(tickers):
         called['tickers'] = tickers
-        return {tickers[0]: [1, 2]}
+        return 'OVERVIEW'
 
-    monkeypatch.setattr('telegram_bot.update_reddit_data', fake_update)
-    monkeypatch.setattr('telegram_bot.notify_telegram', lambda msg: None)
+    monkeypatch.setattr('telegram_bot.generate_overview', fake_overview)
     update = types.SimpleNamespace(message=DummyMessage('!nvda'))
     context = types.SimpleNamespace()
     asyncio.run(handle_ticker(update, context))
     assert called['tickers'] == ['NVDA']
-    assert update.message.replies == ['NVDA: 2 Reddit posts gefunden.']
+    assert update.message.replies == ['OVERVIEW']

--- a/wallenstein/overview.py
+++ b/wallenstein/overview.py
@@ -1,0 +1,50 @@
+"""Generate price and sentiment overview text for tickers."""
+from __future__ import annotations
+
+import os
+from typing import List
+
+from .db_utils import get_latest_prices
+from .reddit_scraper import update_reddit_data
+from .sentiment import analyze_sentiment_batch, derive_recommendation
+
+DB_PATH = os.getenv("WALLENSTEIN_DB_PATH", "data/wallenstein.duckdb").strip()
+
+
+def generate_overview(tickers: List[str]) -> str:
+    """Return a formatted overview for ``tickers``.
+
+    The overview lists the latest USD prices and a simple Reddit-based
+    sentiment score with a derived recommendation for each ticker.
+    """
+
+    prices_usd = get_latest_prices(DB_PATH, tickers, use_eur=False)
+    try:
+        reddit_posts = update_reddit_data(tickers)
+    except Exception:  # pragma: no cover - network or config issues
+        reddit_posts = {t: [] for t in tickers}
+
+    sentiments = {}
+    for ticker in tickers:
+        posts = reddit_posts.get(ticker, [])
+        texts = [p.get("text", "") for p in posts if p.get("text")]
+        if texts:
+            scores = analyze_sentiment_batch(texts)
+            sentiments[ticker] = sum(scores) / len(scores)
+        else:
+            sentiments[ticker] = 0.0
+
+    price_lines = []
+    sentiment_lines = []
+    for t in tickers:
+        price = prices_usd.get(t)
+        if price is not None:
+            price_lines.append(f"{t}: {price:.2f} USD")
+        else:
+            price_lines.append(f"{t}: n/a")
+
+        sent = sentiments.get(t, 0.0)
+        rec = derive_recommendation(sent)
+        sentiment_lines.append(f"{t}: Sentiment {sent:+.2f} | {rec}")
+
+    return "\ud83d\udcca Wallenstein Übersicht\n" + "\n".join(price_lines + sentiment_lines)


### PR DESCRIPTION
## Summary
- factor out price and sentiment overview into `generate_overview`
- use `generate_overview` from main pipeline and telegram bot
- document `!<ticker>` overview usage and independent main pipeline

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab1b4d699883258ed63e411177bea3