### PR TITLE
Use proper emoji for overview header

### DIFF
--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -1,0 +1,21 @@
+import os
+
+os.environ.setdefault('CLIENT_ID', 'x')
+os.environ.setdefault('CLIENT_SECRET', 'x')
+os.environ.setdefault('TELEGRAM_BOT_TOKEN', 'x')
+
+from wallenstein.overview import generate_overview
+
+
+def test_generate_overview_starts_with_chart_emoji(monkeypatch):
+    def fake_get_latest_prices(db_path, tickers, use_eur=False):
+        return {t: 1.23 for t in tickers}
+
+    def fake_update_reddit_data(tickers):
+        return {t: [] for t in tickers}
+
+    monkeypatch.setattr('wallenstein.overview.get_latest_prices', fake_get_latest_prices)
+    monkeypatch.setattr('wallenstein.overview.update_reddit_data', fake_update_reddit_data)
+
+    result = generate_overview(['NVDA'])
+    assert result.startswith("📊 Wallenstein Übersicht\n")

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -1,5 +1,24 @@
 import asyncio
+import os
+import sys
 import types
+
+# Provide dummy telegram modules so that telegram_bot can be imported
+sys.modules.setdefault('telegram', types.SimpleNamespace(Update=object))
+sys.modules.setdefault(
+    'telegram.ext',
+    types.SimpleNamespace(
+        ApplicationBuilder=object,
+        ContextTypes=types.SimpleNamespace(DEFAULT_TYPE=object),
+        MessageHandler=object,
+        filters=types.SimpleNamespace(TEXT=None, COMMAND=None),
+    ),
+)
+
+# Ensure required environment variables exist
+os.environ.setdefault('CLIENT_ID', 'x')
+os.environ.setdefault('CLIENT_SECRET', 'x')
+os.environ.setdefault('TELEGRAM_BOT_TOKEN', 'x')
 
 from telegram_bot import handle_ticker
 

--- a/wallenstein/overview.py
+++ b/wallenstein/overview.py
@@ -47,4 +47,4 @@ def generate_overview(tickers: List[str]) -> str:
         rec = derive_recommendation(sent)
         sentiment_lines.append(f"{t}: Sentiment {sent:+.2f} | {rec}")
 
-    return "\ud83d\udcca Wallenstein Übersicht\n" + "\n".join(price_lines + sentiment_lines)
+    return "📊 Wallenstein Übersicht\n" + "\n".join(price_lines + sentiment_lines)


### PR DESCRIPTION
## Summary
- replace surrogate pair with literal chart emoji in overview output
- stub telegram dependencies in tests and add test ensuring emoji header

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab1ebb372c83259790db96d6c09280