### PR TITLE
Include Tesla and filter Reddit posts by ticker mentions

### DIFF
--- a/main.py
+++ b/main.py
@@ -43,7 +43,14 @@ STOCK_OVERVIEW_DIR = "stockOverview"
 os.makedirs(STOCK_OVERVIEW_DIR, exist_ok=True)
 
 # Ticker
-TICKERS = [t.strip().upper() for t in os.getenv("WALLENSTEIN_TICKERS", "NVDA,AMZN,SMCI").split(",") if t.strip()]
+# Standardmäßig auch Tesla (TSLA) berücksichtigen
+TICKERS = [
+    t.strip().upper()
+    for t in os.getenv(
+        "WALLENSTEIN_TICKERS", "NVDA,AMZN,SMCI,TSLA"
+    ).split(",")
+    if t.strip()
+]
 
 # Telegram (nicht direkt genutzt, aber zur Rückwärtskompatibilität beibehalten)
 TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN", "").strip()
@@ -73,7 +80,9 @@ def main() -> int:
     # 2) Reddit-Daten aktualisieren
     try:
         reddit_posts = update_reddit_data(
-            TICKERS, ["wallstreetbets", "wallstreetbetsGer", "mauerstrassenwetten"]
+            TICKERS,
+            ["wallstreetbets", "wallstreetbetsGer", "mauerstrassenwetten"],
+            include_comments=True,
         )
         log.info("✅ Reddit-Daten aktualisiert")
     except Exception as e:

--- a/wallenstein/reddit_scraper.py
+++ b/wallenstein/reddit_scraper.py
@@ -333,6 +333,14 @@ def update_reddit_data(
     df = _load_posts_from_db()
     df["combined"] = df["title"].fillna("") + "\n" + df["text"].fillna("")
 
+    # Nur Posts weiterverarbeiten, die überhaupt einen der Ticker erwähnen
+    patterns: List[str] = []
+    for tkr in tickers:
+        patterns.extend(p.pattern for p in _compile_patterns(tkr))
+    if patterns:
+        combined_pattern = "|".join(patterns)
+        df = df[df["combined"].str.contains(combined_pattern, regex=True, case=False, na=False)]
+
     # 3) Je Ticker Texte sammeln
     out: Dict[str, List[dict]] = {}
     for tkr in tickers:


### PR DESCRIPTION
## Summary
- Add Tesla (TSLA) to default tickers and enable comment scraping in Reddit updates
- Filter Reddit posts to only those mentioning requested tickers for cleaner sentiment

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab20780c688325a4e0a66e1477b764