### PR TITLE
Add Yahoo Finance price fallback

### DIFF
--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -19,3 +19,18 @@ def test_generate_overview_starts_with_chart_emoji(monkeypatch):
 
     result = generate_overview(['NVDA'])
     assert result.startswith("📊 Wallenstein Übersicht\n")
+
+
+def test_generate_overview_fetches_missing_price(monkeypatch):
+    def fake_get_latest_prices(db_path, tickers, use_eur=False):
+        return {t: None for t in tickers}
+
+    def fake_update_reddit_data(tickers):
+        return {t: [] for t in tickers}
+
+    monkeypatch.setattr('wallenstein.overview.get_latest_prices', fake_get_latest_prices)
+    monkeypatch.setattr('wallenstein.overview.update_reddit_data', fake_update_reddit_data)
+    monkeypatch.setattr('wallenstein.overview._fetch_latest_price', lambda t: 42.0)
+
+    result = generate_overview(['MSFT'])
+    assert 'MSFT: 42.00 USD' in result

--- a/wallenstein/overview.py
+++ b/wallenstein/overview.py
@@ -2,13 +2,36 @@
 from __future__ import annotations
 
 import os
-from typing import List
+from typing import List, Optional
 
 from .db_utils import get_latest_prices
 from .reddit_scraper import update_reddit_data
 from .sentiment import analyze_sentiment_batch, derive_recommendation
 
 DB_PATH = os.getenv("WALLENSTEIN_DB_PATH", "data/wallenstein.duckdb").strip()
+
+
+def _fetch_latest_price(ticker: str) -> Optional[float]:
+    """Fetch the latest USD price for ``ticker`` via yfinance.
+
+    Returns ``None`` if the price cannot be retrieved. This is used as a
+    fallback when the DuckDB database has no entry for the requested ticker,
+    e.g. on weekends or for tickers that were never updated before.
+    """
+    try:
+        import yfinance as yf
+
+        tk = yf.Ticker(ticker)
+        # Try fast_info first (no additional network call); fall back to history
+        price = getattr(getattr(tk, "fast_info", None), "last_price", None)
+        if price is None:
+            hist = tk.history(period="1d", interval="1d", auto_adjust=False,
+                              actions=False)
+            if hist is not None and not hist.empty:
+                price = float(hist["Close"].iloc[-1])
+        return float(price) if price is not None else None
+    except Exception:  # pragma: no cover - network issues
+        return None
 
 
 def generate_overview(tickers: List[str]) -> str:
@@ -19,6 +42,12 @@ def generate_overview(tickers: List[str]) -> str:
     """
 
     prices_usd = get_latest_prices(DB_PATH, tickers, use_eur=False)
+    # Fallback: fetch missing prices via yfinance
+    missing = [t for t in tickers if prices_usd.get(t) is None]
+    for t in missing:
+        px = _fetch_latest_price(t)
+        if px is not None:
+            prices_usd[t] = px
     try:
         reddit_posts = update_reddit_data(tickers)
     except Exception:  # pragma: no cover - network or config issues


### PR DESCRIPTION
## Summary
- use yfinance to look up latest price when DuckDB has no data
- extend overview tests to cover price-fallback behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab230224c88325bb79cea495a1d93c