### PR TITLE
Expand Wallenstein workflow schedule

### DIFF
--- a/.github/workflows/run_script.yml
+++ b/.github/workflows/run_script.yml
@@ -3,7 +3,8 @@ name: Wallenstein Pipeline
 on:
   workflow_dispatch:
   schedule:
-    - cron: "5 6 * * 1-5"  # 07:05 Europe/Berlin (GitHub Actions uses UTC)
+    - cron: "0 7-15 * * 1-5"  # stündlich 08:00–16:00 CET (UTC-Umrechnung beachten)
+    - cron: "0 6-14 * * 1-5"  # stündlich 08:00–16:00 CEST (Sommerzeit)
 
 env:
   PIP_DISABLE_PIP_VERSION_CHECK: "1"


### PR DESCRIPTION
## Summary
- run workflow hourly on weekdays between 08:00 and 16:00 CET
- add second schedule for CEST to cover daylight saving time

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab3db66b1483259e557fd569882fdc