### PR TITLE
Fix datetime normalization after timezone removal

### DIFF
--- a/main.py
+++ b/main.py
@@ -131,9 +131,11 @@ def run_pipeline(tickers: list[str] | None = None) -> int:
 
             # Erwartete Spalte: "created_utc" (Unix oder ISO)
             if "created_utc" in df_posts:
-                df_posts["date"] = pd.to_datetime(
-                    df_posts["created_utc"], errors="coerce", utc=True
-                ).dt.tz_localize(None).normalize()
+                df_posts["date"] = (
+                    pd.to_datetime(df_posts["created_utc"], errors="coerce", utc=True)
+                    .dt.tz_localize(None)
+                    .dt.normalize()
+                )
             else:
                 df_posts["date"] = pd.NaT
 


### PR DESCRIPTION
## Summary
- ensure sentiment post dates keep datetime accessor when removing timezone

## Testing
- `python main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab419fb4448325885db71f4138dc90