### PR TITLE
Allow Telegram notifications without Reddit credentials

### DIFF
--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -1,0 +1,36 @@
+from wallenstein.notify import notify_telegram
+
+
+class DummyResponse:
+    ok = True
+
+    @staticmethod
+    def json():
+        return {"ok": True}
+
+
+def test_notify_telegram_without_reddit_credentials(monkeypatch):
+    """notify_telegram should work without Reddit env vars."""
+    monkeypatch.delenv("CLIENT_ID", raising=False)
+    monkeypatch.delenv("CLIENT_SECRET", raising=False)
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "token")
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "123")
+
+    called = {}
+
+    def fake_post(url, data):
+        called["url"] = url
+        called["data"] = data
+        return DummyResponse()
+
+    monkeypatch.setattr("wallenstein.notify.requests.post", fake_post)
+
+    assert notify_telegram("hi there") is True
+    assert called["url"].endswith("bottoken/sendMessage")
+    assert called["data"]["chat_id"] == "123"
+
+
+def test_notify_telegram_missing_config(monkeypatch):
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("TELEGRAM_CHAT_ID", raising=False)
+    assert notify_telegram("hi") is False

--- a/wallenstein/config.py
+++ b/wallenstein/config.py
@@ -4,18 +4,14 @@ from dotenv import load_dotenv
 # .env laden
 load_dotenv()
 
-def _require(name: str) -> str:
-    val = os.getenv(name)
-    if not val:
-        raise RuntimeError(f"Missing required env var: {name}")
-    return val
-
-CLIENT_ID = _require("CLIENT_ID")
-CLIENT_SECRET = _require("CLIENT_SECRET")
+# Environment variables are accessed lazily so that modules only using
+# Telegram notifications don't require Reddit credentials at import time.
+CLIENT_ID = os.getenv("CLIENT_ID")
+CLIENT_SECRET = os.getenv("CLIENT_SECRET")
 USER_AGENT = os.getenv("USER_AGENT", "Wallenstein")
 
 GOOGLE_API_KEYFILE = os.getenv("GOOGLE_API_KEYFILE")
-GOOGLE_SHEETS_ID   = os.getenv("GOOGLE_SHEETS_ID")
+GOOGLE_SHEETS_ID = os.getenv("GOOGLE_SHEETS_ID")
 
-TELEGRAM_BOT_TOKEN = _require("TELEGRAM_BOT_TOKEN")
-TELEGRAM_CHAT_ID   = int(os.getenv("TELEGRAM_CHAT_ID", "0"))
+TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
+TELEGRAM_CHAT_ID = int(os.getenv("TELEGRAM_CHAT_ID", "0"))

--- a/wallenstein/notify.py
+++ b/wallenstein/notify.py
@@ -1,19 +1,22 @@
 import logging
+import os
 
 import requests
-from . import config
 
 
 log = logging.getLogger(__name__)
 
+
 def notify_telegram(text: str) -> bool:
-    if not text or not config.TELEGRAM_BOT_TOKEN or config.TELEGRAM_CHAT_ID == 0:
+    token = os.getenv("TELEGRAM_BOT_TOKEN")
+    chat_id = os.getenv("TELEGRAM_CHAT_ID")
+    if not text or not token or not chat_id:
         log.warning("⚠️ Telegram nicht konfiguriert oder Chat-ID fehlt.")
         return False
     try:
         r = requests.post(
-            f"https://api.telegram.org/bot{config.TELEGRAM_BOT_TOKEN}/sendMessage",
-            data={"chat_id": config.TELEGRAM_CHAT_ID, "text": text, "parse_mode": "Markdown"}
+            f"https://api.telegram.org/bot{token}/sendMessage",
+            data={"chat_id": chat_id, "text": text, "parse_mode": "Markdown"}
         )
         ok = r.ok and r.json().get("ok", False)
         if ok:
@@ -22,9 +25,6 @@ def notify_telegram(text: str) -> bool:
             log.warning(f"⚠️ Telegram-API Response: {r.text}")
         return ok
     except Exception as e:
-
         log.error(f"❌ Telegram-Error: {e}")
-
         print(f"❌ Telegram-Error: {e}")
-
         return False


### PR DESCRIPTION
## Summary
- Read Telegram token and chat ID directly from environment in `notify_telegram`
- Load config values lazily so Reddit credentials are optional
- Add tests ensuring Telegram notifications work without Reddit secrets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab4dd80288832599007f76e946ea0d