### PR TITLE
Allow Reddit credentials via fallback env vars

### DIFF
--- a/wallenstein/config.py
+++ b/wallenstein/config.py
@@ -4,14 +4,27 @@ from dotenv import load_dotenv
 # .env laden
 load_dotenv()
 
-def _require(name: str) -> str:
+def _require(name: str, alt_name: str | None = None) -> str:
+    """Return the value of an environment variable.
+
+    Parameters
+    ----------
+    name:
+        Primary environment variable name.
+    alt_name:
+        Optional fallback name that is checked when ``name`` is unset.
+    """
+
     val = os.getenv(name)
+    if not val and alt_name:
+        val = os.getenv(alt_name)
     if not val:
         raise RuntimeError(f"Missing required env var: {name}")
     return val
 
-CLIENT_ID = _require("CLIENT_ID")
-CLIENT_SECRET = _require("CLIENT_SECRET")
+# Support Reddit-specific variable names for backwards compatibility
+CLIENT_ID = _require("CLIENT_ID", "REDDIT_CLIENT_ID")
+CLIENT_SECRET = _require("CLIENT_SECRET", "REDDIT_CLIENT_SECRET")
 USER_AGENT = os.getenv("USER_AGENT", "Wallenstein")
 
 GOOGLE_API_KEYFILE = os.getenv("GOOGLE_API_KEYFILE")


### PR DESCRIPTION
## Summary
- support `REDDIT_CLIENT_ID` and `REDDIT_CLIENT_SECRET` fallbacks in config

## Testing
- `pytest`
- `act -W .github/workflows/run_script.yml -s TELEGRAM_BOT_TOKEN=x -s TELEGRAM_CHAT_ID=123 -s REDDIT_CLIENT_ID=x -s REDDIT_CLIENT_SECRET=x -s REDDIT_USER_AGENT=x -P ubuntu-latest=ghcr.io/catthehacker/ubuntu:act-latest` *(fails: Could not find any stages to run)*
- `CLIENT_ID=x CLIENT_SECRET=x TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 python - <<'PY' ...` *(fails: proxy 403 when contacting Telegram API)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4dd5c16883259a7bb4abc8fd3df5