### PR TITLE
Limit workflow to hourly schedule

### DIFF
--- a/.github/workflows/run_script.yml
+++ b/.github/workflows/run_script.yml
@@ -2,15 +2,12 @@ name: Wallenstein Pipeline
 
 on:
   workflow_dispatch:
-  # schedule disabled to prevent frequent runs
-  # schedule:
-  #   - cron: "0 7-15 * * 1-5"  # stündlich 08:00–16:00 CET (UTC-Umrechnung beachten)
-  #   - cron: "0 6-14 * * 1-5"  # stündlich 08:00–16:00 CEST (Sommerzeit)
-  #   - cron: "30 14-21 * * 1-5" # stündlich 15:30–22:30 CET / 16:30–23:30 CEST
-  #   # Winterzeit (CET): 07–22 UTC = 08:05–23:05 lokal
-  #   - cron: "5 7-22 * * 1-5"
-  #   # Sommerzeit (CEST): 06–21 UTC = 08:05–23:05 lokal
-  #   - cron: "5 6-21 * * 1-5"
+  schedule:
+    - cron: "5 7-21 * * 1-5"  # läuft jede Stunde 07–21 UTC (08–22 lokal)
+
+concurrency:
+  group: wallenstein-pipeline
+  cancel-in-progress: false
 
 env:
   PIP_DISABLE_PIP_VERSION_CHECK: "1"


### PR DESCRIPTION
## Summary
- run workflow hourly between 07:00–21:00 UTC
- avoid parallel workflow runs with concurrency group

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acb20180bc83258bb639b897781036