### PR TITLE
Use yfinance for price data and show EUR quotes

### DIFF
--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -9,7 +9,7 @@ from wallenstein.overview import generate_overview
 
 def test_generate_overview_starts_with_chart_emoji(monkeypatch):
     def fake_get_latest_prices(db_path, tickers, use_eur=False):
-        return {t: 1.23 for t in tickers}
+        return {t: (1.11 if use_eur else 2.22) for t in tickers}
 
     def fake_update_reddit_data(tickers):
         return {t: [] for t in tickers}
@@ -31,6 +31,7 @@ def test_generate_overview_fetches_missing_price(monkeypatch):
     monkeypatch.setattr('wallenstein.overview.get_latest_prices', fake_get_latest_prices)
     monkeypatch.setattr('wallenstein.overview.update_reddit_data', fake_update_reddit_data)
     monkeypatch.setattr('wallenstein.overview._fetch_latest_price', lambda t: 42.0)
+    monkeypatch.setattr('wallenstein.overview._fetch_usd_per_eur_rate', lambda: 2.0)
 
     result = generate_overview(['MSFT'])
-    assert 'MSFT: 42.00 USD' in result
+    assert 'MSFT: 42.00 USD (21.00 EUR)' in result

--- a/wallenstein/stock_data.py
+++ b/wallenstein/stock_data.py
@@ -26,9 +26,9 @@ STOOQ_HEADERS = {
     )
 }
 
-# Datenquelle: stooq (default, mit Yahoo-Fallback) | yahoo
+# Datenquelle: yahoo (default) oder stooq (mit Yahoo-Fallback)
 # 'hybrid' bleibt aus Kompatibilitätsgründen als Alias zu stooq bestehen
-DATA_SOURCE = os.getenv("WALLENSTEIN_DATA_SOURCE", "stooq").strip().lower()
+DATA_SOURCE = os.getenv("WALLENSTEIN_DATA_SOURCE", "yahoo").strip().lower()
 
 log = logging.getLogger(__name__)
 
@@ -248,8 +248,8 @@ def update_prices(db_path: str, tickers: List[str]) -> int:
     """
     Schreibt Daily‑Kurse ins DuckDB‑Schema 'prices'.
     Quelle per ENV (WALLENSTEIN_DATA_SOURCE):
-      - 'stooq'  (default, Stooq mit Yahoo‑Fallback)
-      - 'yahoo'  (nur Yahoo)
+      - 'yahoo'  (default, nur Yahoo)
+      - 'stooq'  (Stooq mit Yahoo‑Fallback)
     'hybrid' funktioniert weiterhin als Alias für 'stooq'.
     """
     if not tickers:


### PR DESCRIPTION
## Summary
- Default price source switched to Yahoo Finance instead of Stooq
- Overview now lists both USD and EUR prices using Yahoo FX data
- Extend tests for EUR price output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad901020f483259dfe612743442681