### PR TITLE
Add trending ticker detection and DB indexes

### DIFF
--- a/scripts/detect_trending.py
+++ b/scripts/detect_trending.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+"""CLI helper to identify trending tickers from Reddit data."""
+
+import argparse
+from wallenstein.reddit_scraper import update_reddit_data, detect_trending_tickers
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Detect trending tickers")
+    parser.add_argument("tickers", nargs="+", help="Tickers to analyse")
+    parser.add_argument("--window-hours", type=int, default=24, help="Recent window in hours")
+    parser.add_argument("--baseline-days", type=int, default=7, help="Baseline period in days")
+    parser.add_argument("--min-mentions", type=int, default=3, help="Minimum mentions to be considered")
+    parser.add_argument(
+        "--ratio", type=float, default=2.0, help="Increase ratio over baseline to flag as trending"
+    )
+    args = parser.parse_args()
+
+    posts = update_reddit_data(args.tickers)
+    trending = detect_trending_tickers(
+        posts,
+        window_hours=args.window_hours,
+        baseline_days=args.baseline_days,
+        min_mentions=args.min_mentions,
+        ratio=args.ratio,
+    )
+    if trending:
+        print("Trending tickers:", ", ".join(trending))
+    else:
+        print("No trending tickers detected")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_stock_data.py
+++ b/tests/test_stock_data.py
@@ -84,3 +84,14 @@ def test_stooq_fetch_one_retries(monkeypatch):
     df = stock_data._stooq_fetch_one("TEST", session=sess)
     assert sess.calls == 2
     assert not df.empty
+
+
+def test_prices_table_has_index(tmp_path):
+    db = tmp_path / "idx.duckdb"
+    con = duckdb.connect(str(db))
+    stock_data._ensure_prices_table(con)
+    idx_count = con.execute(
+        "SELECT COUNT(*) FROM duckdb_indexes() WHERE index_name='prices_ticker_date_idx'"
+    ).fetchone()[0]
+    con.close()
+    assert idx_count == 1

--- a/tests/test_trending.py
+++ b/tests/test_trending.py
@@ -1,0 +1,21 @@
+from datetime import datetime, timedelta, timezone
+
+from wallenstein.reddit_scraper import detect_trending_tickers
+
+
+def test_detect_trending_tickers():
+    now = datetime.now(timezone.utc)
+    data = {
+        "AAA": [
+            {"created_utc": now - timedelta(hours=1), "text": "aaa"},
+            {"created_utc": now - timedelta(hours=2), "text": "aaa"},
+            {"created_utc": now - timedelta(hours=3), "text": "aaa"},
+        ],
+        "BBB": [
+            {"created_utc": now - timedelta(days=2), "text": "bbb"},
+            {"created_utc": now - timedelta(days=3), "text": "bbb"},
+        ],
+    }
+    trending = detect_trending_tickers(data, window_hours=24, baseline_days=7, min_mentions=3, ratio=2.0)
+    assert "AAA" in trending
+    assert "BBB" not in trending

--- a/wallenstein/sentiment.py
+++ b/wallenstein/sentiment.py
@@ -74,6 +74,9 @@ KEYWORD_SCORES: Dict[str, int] = {
     "fomo": 1,
     "hodl": 1,
     "btfd": 1,
+    "rocket": 1,
+    "squeeze": 1,
+    "lfg": 1,
     # negative
     "short": -1,
     "put": -1,
@@ -84,8 +87,10 @@ KEYWORD_SCORES: Dict[str, int] = {
     "bärisch": -1,
     "dip": -1,
     "dump": -1,
+    "dumping": -1,
     "fud": -1,
     "crash": -1,
+    "bagholder": -1,
 }
 
 # extend keyword scores with simple intensity phrases and negated forms

--- a/wallenstein/stock_data.py
+++ b/wallenstein/stock_data.py
@@ -63,6 +63,13 @@ def _ensure_prices_table(con: duckdb.DuckDBPyConnection):
             volume BIGINT
         )
     """)
+    # Index für häufige Abfragen (Ticker + Datum)
+    try:
+        con.execute(
+            "CREATE INDEX IF NOT EXISTS prices_ticker_date_idx ON prices(ticker, date)"
+        )
+    except Exception:
+        pass  # pragma: no cover - defensive: ältere DuckDB-Versionen ohne Index-Unterstützung
 
 def _latest_dates_per_ticker(con: duckdb.DuckDBPyConnection, tickers: List[str]) -> Dict[str, Optional[date]]:
     if not tickers:


### PR DESCRIPTION
## Summary
- add index on `prices(ticker, date)` and `reddit_posts(created_utc)` for faster queries
- extend keyword-based sentiment with common trading slang
- implement `detect_trending_tickers` helper and CLI to spot Reddit momentum

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68adbd398b408325a16a424652291e12