### PR TITLE
Trim dependencies and guard optional FinBERT training

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -4,8 +4,4 @@ duckdb
 requests
 python-dotenv
 praw
-nltk
 scikit-learn
-transformers
-torch
-tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,4 @@ duckdb==0.10.2
 requests==2.32.3
 python-dotenv==1.0.1
 praw==7.7.1
-nltk==3.8.1
 scikit-learn==1.4.2
-transformers==4.41.0
-torch==2.2.1
-tqdm==4.66.4

--- a/scripts/train_finbert.py
+++ b/scripts/train_finbert.py
@@ -1,29 +1,35 @@
+import sys
 import numpy as np
-from datasets import load_dataset
-from sklearn.metrics import accuracy_score, precision_score, recall_score
-from transformers import (
-    AutoModelForSequenceClassification,
-    AutoTokenizer,
-    Trainer,
-    TrainingArguments,
-)
 
 
 def tokenize_function(examples, tokenizer):
     return tokenizer(examples["text"], padding="max_length", truncation=True)
 
 
-def compute_metrics(p):
-    preds = np.argmax(p.predictions, axis=1)
-    labels = p.label_ids
-    return {
-        "accuracy": accuracy_score(labels, preds),
-        "precision": precision_score(labels, preds),
-        "recall": recall_score(labels, preds),
-    }
-
-
 def main():
+    try:
+        from datasets import load_dataset
+        from sklearn.metrics import accuracy_score, precision_score, recall_score
+        from transformers import (
+            AutoModelForSequenceClassification,
+            AutoTokenizer,
+            Trainer,
+            TrainingArguments,
+        )
+    except Exception as exc:
+        print("Missing optional dependencies for FinBERT training: datasets, transformers, scikit-learn")
+        print(exc)
+        return
+
+    def compute_metrics(p):
+        preds = np.argmax(p.predictions, axis=1)
+        labels = p.label_ids
+        return {
+            "accuracy": accuracy_score(labels, preds),
+            "precision": precision_score(labels, preds),
+            "recall": recall_score(labels, preds),
+        }
+
     dataset = load_dataset("csv", data_files={"data": "data/sentiment_labels.csv"})["data"]
     dataset = dataset.train_test_split(test_size=0.2, seed=42)
 


### PR DESCRIPTION
## Summary
- remove optional ML libraries from requirements
- add runtime checks for missing packages in `train_finbert.py`

## Testing
- `pytest` *(fails: notify_telegram, fetch_reddit_posts, sentiment negation, analyze_sentiment_batch_keyword, update_prices)*

------
https://chatgpt.com/codex/tasks/task_e_68adce8dd0f4832596c9425e4868add9