### PR TITLE
Refactor reddit posts schema and scraper

### DIFF
--- a/wallenstein/db_schema.py
+++ b/wallenstein/db_schema.py
@@ -13,9 +13,8 @@ SCHEMAS = {
     "reddit_posts": {
         "id": "TEXT",
         "created_utc": "TIMESTAMP",
-        "ticker": "TEXT",
         "title": "TEXT",
-        "selftext": "TEXT",
+        "text": "TEXT",
     },
     "sentiments": {
         "post_id": "TEXT",


### PR DESCRIPTION
## Summary
- simplify `reddit_posts` schema to only store post `id`, `created_utc`, `title`, and `text`
- align Reddit scraper with new schema and load credentials from settings/env vars

## Testing
- `pytest tests/test_reddit_scraper.py::test_fetches_hot_and_new_posts_with_comments -q`
- `python - <<'PY'
from wallenstein import reddit_scraper
import pandas as pd

reddit_scraper.fetch_reddit_posts = lambda *a,**k: pd.DataFrame()
reddit_scraper._load_posts_from_db = lambda: pd.DataFrame(columns=['id','created_utc','title','text'])
reddit_scraper.purge_old_posts = lambda: None

print(reddit_scraper.update_reddit_data(['NVDA'], subreddits=None))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68adeed006f08325be73b92457c27ff2