### PR TITLE
Handle Yahoo 429 rate limits with backoff

### DIFF
--- a/wallenstein/db_schema.py
+++ b/wallenstein/db_schema.py
@@ -8,6 +8,7 @@ SCHEMAS = {
         "high": "DOUBLE",
         "low": "DOUBLE",
         "close": "DOUBLE",
+        "adj_close": "DOUBLE",
         "volume": "BIGINT",
     },
     "reddit_posts": {

--- a/wallenstein/stock_data.py
+++ b/wallenstein/stock_data.py
@@ -1,6 +1,7 @@
 import io
 import json
 import logging
+import random
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import date
@@ -10,14 +11,17 @@ import pandas as pd
 import requests
 import yfinance as yf
 from requests.adapters import HTTPAdapter
+from requests.exceptions import HTTPError
 from urllib3.util.retry import Retry
 
 from wallenstein.config import settings
 from wallenstein.db_schema import ensure_tables, validate_df
 
 # ---- Configuration ----
-MAX_RETRIES = 3
+MAX_RETRIES = 6
 CHUNK_SIZE = 20
+# limit yahoo concurrency to reduce risk of 429s
+YAHOO_MAX_WORKERS = 3
 # User-Agent for Stooq requests (some environments return 403 for default UA)
 STOOQ_HEADERS = {"User-Agent": settings.STOOQ_USER_AGENT}
 
@@ -93,7 +97,9 @@ def _latest_dates_per_ticker(
 
 
 def _retry_sleep(attempt: int):
-    time.sleep(1.0 * (2**attempt))  # 1s, 2s, 4s
+    """Sleep with exponential backoff and jitter."""
+    base = 1.0 * (2**attempt)
+    time.sleep(base + random.random())
 
 
 # ---- Stooq (stable, CSV) ----
@@ -179,14 +185,15 @@ def _make_session(user_agent: str | None = None) -> requests.Session:
             "Accept": "*/*",
             "Accept-Language": "en-US,en;q=0.9,de-DE;q=0.8",
             "Connection": "keep-alive",
-            "Referer": "https://finance.yahoo.com/",
+        "Referer": "https://finance.yahoo.com/",
         }
     )
     retry = Retry(
-        total=3,
-        backoff_factor=1.2,
+        total=MAX_RETRIES,
+        backoff_factor=1.0,
         status_forcelist=[429, 500, 502, 503, 504],
         allowed_methods=["HEAD", "GET", "OPTIONS"],
+        respect_retry_after_header=True,
     )
     adapter = HTTPAdapter(max_retries=retry, pool_connections=8, pool_maxsize=16)
     s.mount("https://", adapter)
@@ -250,6 +257,12 @@ def _download_single_safe(
         except json.JSONDecodeError:
             _retry_sleep(attempt)
             continue
+        except HTTPError as e:
+            status = getattr(e.response, "status_code", None)
+            if status == 429:
+                log.warning(f"{ticker}: rate limited (429), backing off")
+            _retry_sleep(attempt)
+            continue
         except Exception:
             _retry_sleep(attempt)
             continue
@@ -266,7 +279,7 @@ def _yahoo_fetch_many(
     """Fetch multiple tickers from Yahoo concurrently."""
     sess = session or _make_session()
     results: list[pd.DataFrame] = []
-    with ThreadPoolExecutor(max_workers=min(5, len(tickers))) as ex:
+    with ThreadPoolExecutor(max_workers=min(YAHOO_MAX_WORKERS, len(tickers))) as ex:
         futures = {
             ex.submit(
                 _download_single_safe,


### PR DESCRIPTION
## Summary
- add exponential backoff with jitter and higher retry cap for Yahoo price downloads
- limit concurrent Yahoo requests and log 429 rate limiting
- include `adj_close` in DuckDB price schema

## Testing
- `pytest` *(fails: notify/reddit/sentiment tests)*
- manual `_download_single_safe` run with simulated 429 responses


------
https://chatgpt.com/codex/tasks/task_e_68adeecd78948325b234303ad39c7471