### PR TITLE
Refine retry handling in stock data fetch

### DIFF
--- a/wallenstein/stock_data.py
+++ b/wallenstein/stock_data.py
@@ -14,8 +14,6 @@ from requests.adapters import HTTPAdapter
 
 from requests.exceptions import HTTPError, RequestException
 
-from requests.exceptions import HTTPError
-
 from urllib3.util.retry import Retry
 
 from wallenstein.config import settings
@@ -290,7 +288,7 @@ def _download_single_safe(
         except Exception as e:  # pragma: no cover - defensive catch-all
             last_err = e
 
-        # Nur wenn weitere Versuche übrig sind: Backoff + weiter
+        # Backoff and retry if attempts remain
         if attempt < MAX_RETRIES - 1:
             _retry_sleep(attempt)
             continue


### PR DESCRIPTION
## Summary
- clarify retry loop by backing off and continuing when attempts remain
- remove redundant HTTPError import

## Testing
- `python -m py_compile wallenstein/stock_data.py`
- `pytest` *(fails: IndexError and assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_68adf3f310ac832584d621e3bc278fbf