### PR TITLE
feat: add Stooq fallback for Yahoo data fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Projekt Wallenstein — Final Pack
 
 This is a ready-to-push bundle. It includes:
-- Robust price updater with DuckDB storage
+- Robust price updater with DuckDB storage (Stooq default with Yahoo/Stooq fallback)
 - Reddit sentiment integration (PRAW) with basic English/German keyword analysis
 - Telegram alerts (optional)
 
@@ -44,6 +44,7 @@ pre-commit install
 - `WALLENSTEIN_DB_PATH` = path to DuckDB (default `data/wallenstein.duckdb`)
 - `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID` (optional alerts)
 - `REDDIT_CLIENT_ID`, `REDDIT_CLIENT_SECRET`, `REDDIT_USER_AGENT` (optional for true Reddit scraping)
+- `WALLENSTEIN_DATA_SOURCE` = `stooq` (default) uses Stooq with Yahoo fallback; set to `yahoo` to use Yahoo with a Stooq fallback for missing tickers
 - `USE_BERT_SENTIMENT` = choose sentiment backend. When unset the app uses a
   BERT model if the `transformers` package is available, otherwise a lightweight
   keyword approach. Set to `1`/`true` to force BERT or `0`/`false` to force the

--- a/wallenstein/config.py
+++ b/wallenstein/config.py
@@ -21,7 +21,7 @@ class Settings:
     REQUEST_TIMEOUT = int(os.getenv("REQUEST_TIMEOUT", "15"))
     MAX_RETRIES = int(os.getenv("MAX_RETRIES", "5"))
     WALLENSTEIN_TICKERS = os.getenv("WALLENSTEIN_TICKERS", "NVDA,AMZN,SMCI,TSLA")
-    WALLENSTEIN_DATA_SOURCE = os.getenv("WALLENSTEIN_DATA_SOURCE", "yahoo").strip().lower()
+    WALLENSTEIN_DATA_SOURCE = os.getenv("WALLENSTEIN_DATA_SOURCE", "stooq").strip().lower()
     STOOQ_USER_AGENT = os.getenv(
         "STOOQ_USER_AGENT",
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "


### PR DESCRIPTION
## Summary
- default to Stooq data source for greater stability
- add Stooq fallback when Yahoo is missing tickers
- document hybrid data-source behavior in docs

## Testing
- `pytest` (fails: tests/test_notify.py::test_notify_telegram_without_reddit_credentials, tests/test_sentiment.py::test_env_switches_to_bert)
- `ruff check wallenstein/stock_data.py wallenstein/config.py`


------
https://chatgpt.com/codex/tasks/task_e_68adf3f624f483258b8ecc8471e0b8b2