### PR TITLE
Add composite key for prices and dedupe inserts

### DIFF
--- a/wallenstein/db_schema.py
+++ b/wallenstein/db_schema.py
@@ -38,6 +38,8 @@ SCHEMAS = {
 def ensure_tables(con: duckdb.DuckDBPyConnection):
     for table, cols in SCHEMAS.items():
         coldefs = ", ".join(f"{c} {t}" for c, t in cols.items())
+        if table == "prices":
+            coldefs += ", PRIMARY KEY (date, ticker)"
         con.execute(f"CREATE TABLE IF NOT EXISTS {table} ({coldefs});")
         if table == "reddit_posts":
             info = con.execute("PRAGMA table_info('reddit_posts')").fetchall()

--- a/wallenstein/stock_data.py
+++ b/wallenstein/stock_data.py
@@ -72,7 +72,8 @@ def _ensure_prices_table(con: duckdb.DuckDBPyConnection):
             low DOUBLE,
             close DOUBLE,
             adj_close DOUBLE,
-            volume BIGINT
+            volume BIGINT,
+            PRIMARY KEY(date, ticker)
         )
     """
     )
@@ -441,15 +442,9 @@ def update_prices(db_path: str, tickers: list[str]) -> int:
     df_all["date"] = pd.to_datetime(df_all["date"]).dt.date
     df_all = df_all.sort_values(["ticker", "date"])
 
-    # Append + DISTINCT‑Refresh
+    # Append while skipping duplicates
     validate_df(df_all, "prices")
-    con.execute("INSERT INTO prices SELECT * FROM df_all")
-    con.execute(
-        """
-        CREATE OR REPLACE TABLE prices AS
-        SELECT DISTINCT * FROM prices
-    """
-    )
+    con.execute("INSERT INTO prices SELECT * FROM df_all ON CONFLICT DO NOTHING")
 
     n = len(df_all)
     if session is not None:


### PR DESCRIPTION
## Summary
- enforce uniqueness on `prices` by adding `PRIMARY KEY(date, ticker)`
- simplify `update_prices` by using `INSERT ... ON CONFLICT DO NOTHING` instead of a DISTINCT refresh
- ensure helper `_ensure_prices_table` matches the new schema

## Testing
- `PYTHONPATH=. pytest tests/test_stock_data.py -q`
- `PYTHONPATH=. pytest -q` *(fails: notify_telegram_without_reddit_credentials, env_switches_to_bert)*

------
https://chatgpt.com/codex/tasks/task_e_68adfa88e0388325bcfcc52ba9c8e197