### PR TITLE
feat: allow overview with preloaded reddit posts

### DIFF
--- a/main.py
+++ b/main.py
@@ -186,7 +186,7 @@ def run_pipeline(tickers: list[str] | None = None) -> int:
 
     # Übersicht & Notify
     try:
-        msg = generate_overview(tickers)
+        msg = generate_overview(tickers, reddit_posts=reddit_posts)
         notify_telegram(msg)
     except Exception as e:
         log.warning(f"Übersicht/Telegram fehlgeschlagen: {e}")

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -13,8 +13,8 @@ def test_notify_telegram_without_reddit_credentials(monkeypatch):
     """notify_telegram should work without Reddit env vars."""
     monkeypatch.delenv("CLIENT_ID", raising=False)
     monkeypatch.delenv("CLIENT_SECRET", raising=False)
-    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "token")
-    monkeypatch.setenv("TELEGRAM_CHAT_ID", "123")
+    monkeypatch.setattr("wallenstein.notify.settings.TELEGRAM_BOT_TOKEN", "token")
+    monkeypatch.setattr("wallenstein.notify.settings.TELEGRAM_CHAT_ID", "123")
 
     called = {}
 
@@ -31,6 +31,6 @@ def test_notify_telegram_without_reddit_credentials(monkeypatch):
 
 
 def test_notify_telegram_missing_config(monkeypatch):
-    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
-    monkeypatch.delenv("TELEGRAM_CHAT_ID", raising=False)
+    monkeypatch.setattr("wallenstein.notify.settings.TELEGRAM_BOT_TOKEN", None)
+    monkeypatch.setattr("wallenstein.notify.settings.TELEGRAM_CHAT_ID", None)
     assert notify_telegram("hi") is False

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -11,13 +11,9 @@ def test_generate_overview_starts_with_chart_emoji(monkeypatch):
     def fake_get_latest_prices(db_path, tickers, use_eur=False):
         return {t: (1.11 if use_eur else 2.22) for t in tickers}
 
-    def fake_update_reddit_data(tickers):
-        return {t: [] for t in tickers}
-
     monkeypatch.setattr('wallenstein.overview.get_latest_prices', fake_get_latest_prices)
-    monkeypatch.setattr('wallenstein.overview.update_reddit_data', fake_update_reddit_data)
 
-    result = generate_overview(['NVDA'])
+    result = generate_overview(['NVDA'], reddit_posts={'NVDA': []})
     assert result.startswith("📊 Wallenstein Übersicht\n")
 
 
@@ -25,13 +21,9 @@ def test_generate_overview_fetches_missing_price(monkeypatch):
     def fake_get_latest_prices(db_path, tickers, use_eur=False):
         return {t: None for t in tickers}
 
-    def fake_update_reddit_data(tickers):
-        return {t: [] for t in tickers}
-
     monkeypatch.setattr('wallenstein.overview.get_latest_prices', fake_get_latest_prices)
-    monkeypatch.setattr('wallenstein.overview.update_reddit_data', fake_update_reddit_data)
     monkeypatch.setattr('wallenstein.overview._fetch_latest_price', lambda t: 42.0)
     monkeypatch.setattr('wallenstein.overview._fetch_usd_per_eur_rate', lambda: 2.0)
 
-    result = generate_overview(['MSFT'])
+    result = generate_overview(['MSFT'], reddit_posts={'MSFT': []})
     assert 'MSFT: 42.00 USD (21.00 EUR)' in result

--- a/tests/test_sentiment.py
+++ b/tests/test_sentiment.py
@@ -21,8 +21,7 @@ from wallenstein.sentiment import (
 @pytest.fixture(autouse=True)
 def _disable_bert(monkeypatch):
     """Use keyword sentiment by default for tests."""
-
-    monkeypatch.setenv("USE_BERT_SENTIMENT", "0")
+    monkeypatch.setattr(sentiment.settings, "USE_BERT_SENTIMENT", False)
 
 def test_analyze_sentiment_keywords():
     text = "I'm going long and want to buy more calls, not sell"
@@ -68,9 +67,9 @@ def test_env_switches_to_bert(monkeypatch):
     with patch("wallenstein.sentiment.BertSentiment") as MockBert:
         sentiment._bert_analyzer = None
         MockBert.return_value.return_value = [{"label": "positive", "score": 0.9}]
-        monkeypatch.setenv("USE_BERT_SENTIMENT", "1")
+        monkeypatch.setattr(sentiment.settings, "USE_BERT_SENTIMENT", True)
         assert analyze_sentiment("whatever") > 0
-        monkeypatch.delenv("USE_BERT_SENTIMENT", raising=False)
+        monkeypatch.setattr(sentiment.settings, "USE_BERT_SENTIMENT", False)
         # ensure fallback path still works
         assert analyze_sentiment("buy") > 0
 


### PR DESCRIPTION
## Summary
- allow `generate_overview` to accept optional `reddit_posts` mapping instead of fetching
- pass loaded reddit data from `run_pipeline` to `generate_overview`
- adjust tests to new API and fix config-dependent patches

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adfa8b70c88325a8b21f6c408eb66d