### PR TITLE
Add unique key for fx_rates and simplify updates

### DIFF
--- a/wallenstein/db_utils.py
+++ b/wallenstein/db_utils.py
@@ -21,7 +21,8 @@ def _ensure_fx_table(con: duckdb.DuckDBPyConnection) -> None:
         CREATE TABLE IF NOT EXISTS fx_rates (
             date DATE,
             pair VARCHAR,
-            rate_usd_per_eur DOUBLE
+            rate_usd_per_eur DOUBLE,
+            UNIQUE(date, pair)
         )
     """
     )


### PR DESCRIPTION
## Summary
- enforce unique (date, pair) constraint for fx_rates with index
- simplify FX rate updates using INSERT ... ON CONFLICT DO NOTHING
- ensure fx_rates table creation adds the unique constraint

## Testing
- `pre-commit run --files wallenstein/db_schema.py wallenstein/stock_data.py wallenstein/db_utils.py`
- `PYTHONPATH=$PWD pytest tests/test_stock_data.py tests/test_reddit_scraper.py`


------
https://chatgpt.com/codex/tasks/task_e_68adfa89556c8325b9532d5426e6fc5f