### PR TITLE
feat: add token normalization for sentiment

### DIFF
--- a/tests/test_sentiment.py
+++ b/tests/test_sentiment.py
@@ -36,6 +36,8 @@ def test_analyze_sentiment_keywords():
     assert analyze_sentiment(text5) > 0
     text6 = "Der Verlust ist rot"
     assert analyze_sentiment(text6) < 0
+    text7 = "Er hat die Aktien verkauft"
+    assert analyze_sentiment(text7) < 0
 
 
 def test_aggregate_and_recommendation():


### PR DESCRIPTION
## Summary
- normalize tokens using spaCy/NLTK with suffix-trimming fallback
- preprocess text using the new normalization to improve keyword matching
- add test ensuring "verkauft" is recognized as negative

## Testing
- `pre-commit run --files wallenstein/sentiment.py tests/test_sentiment.py`
- `pytest tests/test_sentiment.py`
- `pytest` *(fails: tests/test_notify.py::test_notify_telegram_without_reddit_credentials, tests/test_stock_data.py::test_update_prices_skips_weekend, tests/test_stock_data.py::test_download_single_safe_handles_429)*

------
https://chatgpt.com/codex/tasks/task_e_68af51a58e8483258f0dea092f476bf4