### PR TITLE
Load ticker aliases from JSON file

### DIFF
--- a/scripts/update_ticker_aliases.py
+++ b/scripts/update_ticker_aliases.py
@@ -1,0 +1,90 @@
+"""Generate ticker alias mapping from a CSV file.
+
+This helper reads symbol/name pairs (e.g. from a Finnhub export) and writes
+``data/ticker_aliases.json`` which is used by :mod:`wallenstein.reddit_scraper`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Common corporate suffixes which are dropped for simplified aliases
+STOPWORDS = {
+    "inc",
+    "corp",
+    "corporation",
+    "company",
+    "co",
+    "plc",
+    "ag",
+    "sa",
+    "se",
+    "nv",
+    "ltd",
+    "holdings",
+    "holding",
+    "group",
+}
+
+
+def _make_aliases(name: str) -> list[str]:
+    """Return a list of alias variants for ``name``."""
+
+    base = name.lower().strip()
+    aliases: set[str] = {base}
+
+    # Replace punctuation with spaces
+    cleaned = re.sub(r"[^a-z0-9]+", " ", base).strip()
+    if cleaned:
+        aliases.add(cleaned)
+
+    # Drop common suffixes
+    tokens = [t for t in cleaned.split() if t not in STOPWORDS]
+    if tokens:
+        aliases.add(" ".join(tokens))
+        aliases.add(tokens[0])
+
+    return sorted(a for a in aliases if a)
+
+
+def main() -> None:  # pragma: no cover - simple utility script
+    parser = argparse.ArgumentParser(description="Create ticker alias mapping")
+    parser.add_argument("csv", help="CSV file with at least 'symbol' and 'name' or 'description' columns")
+    parser.add_argument(
+        "--output",
+        default=ROOT / "data" / "ticker_aliases.json",
+        help="Path to output JSON file",
+    )
+    args = parser.parse_args()
+
+    df = pd.read_csv(args.csv)
+
+    # Determine column names
+    symbol_col = next((c for c in df.columns if c.lower() in {"symbol", "ticker"}), None)
+    name_col = next((c for c in df.columns if c.lower() in {"description", "name", "company"}), None)
+    if not symbol_col or not name_col:
+        raise SystemExit("CSV must contain symbol and name/description columns")
+
+    mapping: dict[str, list[str]] = {}
+    for _, row in df.iterrows():
+        sym = str(row[symbol_col]).upper().strip()
+        name = str(row[name_col])
+        mapping[sym] = _make_aliases(name)
+
+    out_path = Path(args.output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("w", encoding="utf-8") as fh:
+        json.dump(mapping, fh, ensure_ascii=False, indent=4, sort_keys=True)
+
+    print(f"Wrote {len(mapping)} aliases to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_reddit_scraper.py
+++ b/tests/test_reddit_scraper.py
@@ -24,6 +24,7 @@ def test_company_name_bucketed(monkeypatch):
         {"id": "2", "title": "", "created_utc": now, "text": "I ordered something on Amzon"},
         {"id": "3", "title": "", "created_utc": now, "text": "Rheiner secures big contract"},
         {"id": "4", "title": "", "created_utc": now, "text": "Game stop hype again"},
+        {"id": "5", "title": "", "created_utc": now, "text": "Ali babA expands"},
     ])
 
     def fake_fetch(*args, **kwargs):
@@ -33,15 +34,19 @@ def test_company_name_bucketed(monkeypatch):
     monkeypatch.setattr(reddit_scraper, "_load_posts_from_db", lambda: df)
     monkeypatch.setattr(reddit_scraper, "purge_old_posts", lambda: None)
 
-    out = reddit_scraper.update_reddit_data(["NVDA", "AMZN", "RHM", "GME"], subreddits=None)
+    out = reddit_scraper.update_reddit_data(
+        ["NVDA", "AMZN", "RHM", "GME", "BABA"], subreddits=None
+    )
     assert len(out["NVDA"]) == 1
     assert len(out["AMZN"]) == 1
     assert len(out["RHM"]) == 1
     assert len(out["GME"]) == 1
+    assert len(out["BABA"]) == 1
     assert "nividia" in out["NVDA"][0]["text"].lower()
     assert "amzon" in out["AMZN"][0]["text"].lower()
     assert "rheiner" in out["RHM"][0]["text"].lower()
     assert "game stop" in out["GME"][0]["text"].lower()
+    assert "ali baba" in out["BABA"][0]["text"].lower()
 
 
 def test_aliases_loaded_from_file():
@@ -52,7 +57,7 @@ def test_aliases_loaded_from_file():
     try:
         alias_path.write_text(json.dumps({"XYZ": ["some corp"]}))
         importlib.reload(reddit_scraper)
-        assert "some corp" in reddit_scraper.TICKER_NAME_MAP["XYZ"]
+        assert reddit_scraper.TICKER_NAME_MAP == {"XYZ": ["some corp"]}
     finally:
         alias_path.write_text(original)
         importlib.reload(reddit_scraper)

--- a/wallenstein/notify.py
+++ b/wallenstein/notify.py
@@ -10,11 +10,8 @@ log = logging.getLogger(__name__)
 
 def notify_telegram(text: str) -> bool:
 
-    token = os.getenv("TELEGRAM_BOT_TOKEN") or settings.TELEGRAM_BOT_TOKEN
-    chat_id = os.getenv("TELEGRAM_CHAT_ID") or settings.TELEGRAM_CHAT_ID
-
-    token = os.getenv("TELEGRAM_BOT_TOKEN", settings.TELEGRAM_BOT_TOKEN)
-    chat_id = os.getenv("TELEGRAM_CHAT_ID", settings.TELEGRAM_CHAT_ID)
+    token = settings.TELEGRAM_BOT_TOKEN or os.getenv("TELEGRAM_BOT_TOKEN")
+    chat_id = settings.TELEGRAM_CHAT_ID or os.getenv("TELEGRAM_CHAT_ID")
 
     if not text or not token or not chat_id:
         log.warning("⚠️ Telegram nicht konfiguriert oder Chat-ID fehlt.")

--- a/wallenstein/reddit_scraper.py
+++ b/wallenstein/reddit_scraper.py
@@ -32,22 +32,9 @@ DB_PATH = settings.WALLENSTEIN_DB_PATH
 # Anzahl Tage, die Posts in der Datenbank behalten werden
 DATA_RETENTION_DAYS = settings.DATA_RETENTION_DAYS
 
-# Bekannte Firmennamen zu Tickersymbolen.  Diese Liste ist keineswegs
-# vollständig, deckt aber einige der üblichen Verdächtigen ab.  Für jeden
-# Ticker können mehrere Varianten des Firmennamens angegeben werden, die im
-# Text erkannt werden sollen.
-TICKER_NAME_MAP: dict[str, list[str]] = {
-    "NVDA": ["nvidia", "nividia", "nvidea", "NVDA"],
-    "AMZN": ["amazon", "amzon", "amazn", "AMZN"],
-    "AAPL": ["apple", "aple", "appl", "AAPL"],
-    "MSFT": ["microsoft", "micosoft", "micro soft", "MSFT"],
-    "GOOG": ["google", "alphabet", "googel", "gogle"],
-    "META": ["facebook", "meta", "metta", "facebok"],
-    "TSLA": ["tesla", "tesler", "tesal"],
-    "RHM": ["rheinmetall", "rheiner"],
-    "GME": ["gamestop", "game stop", "gme"],
-    "BABA": ["alibaba", "ali baba", "alibba"],
-}
+# Zu Tickersymbolen gehörende Firmennamen/Aliasse.  Die Zuordnung wird beim
+# Import aus ``data/ticker_aliases.*`` geladen und ist hier zunächst leer.
+TICKER_NAME_MAP: dict[str, list[str]] = {}
 
 
 def _load_aliases_from_file(

--- a/wallenstein/stock_data.py
+++ b/wallenstein/stock_data.py
@@ -440,7 +440,7 @@ def _download_single_safe(
         except HTTPError as e:
             status = e.response.status_code if e.response is not None else None
             if status == 429:
-                log.warning(f"{ticker}: HTTP 429 rate-limited -> skip")
+                log.warning(f"{ticker}: HTTP 429 skipped due to rate limiting")
                 return _empty()
             last_err = e
             log.debug(f"{ticker}: HTTPError on attempt {attempt+1}: {e}")
@@ -529,7 +529,13 @@ def update_prices(db_path: str, tickers: list[str]) -> int:
 
     for i in range(0, len(tickers), CHUNK_SIZE):
         chunk = tickers[i : i + CHUNK_SIZE]
-        chunk_valid = list(chunk)  # HEUTE nicht überspringen
+        chunk_valid = [
+            t
+            for t in chunk
+            if start_map.get(t) is None or start_map[t].date() <= last_trading_day
+        ]
+        if not chunk_valid:
+            continue
         log.debug("processing chunk=%s", chunk_valid)
 
         # --- Primärquelle ---


### PR DESCRIPTION
## Summary
- load ticker aliases only from `data/ticker_aliases.*` and keep `TICKER_NAME_MAP` empty by default
- add `scripts/update_ticker_aliases.py` to generate the alias JSON from a CSV export
- cover aliases like BABA in tests and reload mapping from file each run
- fix notify_telegram to favour config over env vars and skip weekend price fetches

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af51a769988325b36795395bc307af