### PR TITLE
Log baseline metrics in train_per_stock

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pandas as pd
 import numpy as np
+import logging
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -49,3 +50,18 @@ def test_train_per_stock_insufficient_classes():
     })
     acc, f1 = train_per_stock(df)
     assert acc is None and f1 is None
+
+
+def test_train_per_stock_baseline_logging(caplog):
+    np.random.seed(2)
+    dates = pd.date_range("2024-01-01", periods=15, freq="D")
+    df = pd.DataFrame({
+        "date": dates,
+        "close": 10 + np.cumsum(np.random.randn(15)),
+        "sentiment": np.random.randn(15),
+    })
+    with caplog.at_level(logging.INFO):
+        train_per_stock(df, n_splits=3)
+    messages = "\n".join(record.message for record in caplog.records)
+    assert "Class distribution" in messages
+    assert "Baseline (majority class" in messages

--- a/wallenstein/models.py
+++ b/wallenstein/models.py
@@ -93,6 +93,31 @@ def train_per_stock(
     X = df[features]
     y = df["y"]
 
+    # Log class distribution
+    class_distribution = y.value_counts().sort_index().to_dict()
+    log.info(f"Class distribution: {class_distribution}")
+
+    # Baseline predictions
+    majority_class = y.mode()[0]
+    majority_pred = pd.Series(majority_class, index=y.index)
+    majority_acc = accuracy_score(y, majority_pred)
+    majority_f1 = f1_score(y, majority_pred, zero_division=0)
+    log.info(
+        "Baseline (majority class %s) accuracy: %.4f, F1: %.4f",
+        majority_class,
+        majority_acc,
+        majority_f1,
+    )
+
+    buy_hold_pred = pd.Series(1, index=y.index)
+    buy_hold_acc = accuracy_score(y, buy_hold_pred)
+    buy_hold_f1 = f1_score(y, buy_hold_pred, zero_division=0)
+    log.info(
+        "Baseline (buy and hold) accuracy: %.4f, F1: %.4f",
+        buy_hold_acc,
+        buy_hold_f1,
+    )
+
     if y.nunique() < 2:
         return None, None
 

--- a/wallenstein/stock_data.py
+++ b/wallenstein/stock_data.py
@@ -440,6 +440,7 @@ def _download_single_safe(
         except HTTPError as e:
             status = e.response.status_code if e.response is not None else None
             if status == 429:
+                log.warning(f"{ticker}: skipped due to rate limiting")
                 return _empty()
             last_err = e
             log.debug(f"{ticker}: HTTPError on attempt {attempt+1}: {e}")


### PR DESCRIPTION
## Summary
- Log class distribution and baseline (majority class and buy-and-hold) accuracy/F1 before model training
- Cover baseline logging with a dedicated unit test
- Warn when Yahoo requests are skipped due to rate limiting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af56f46b8c8325ae99f5a4c271282e