### PR TITLE
Add OHLCV feature support and technical indicators

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -13,11 +13,11 @@ from wallenstein.models import train_per_stock
 
 def test_train_per_stock_basic():
     np.random.seed(0)
-    dates = pd.date_range("2024-01-01", periods=20, freq="D")
+    dates = pd.date_range("2024-01-01", periods=60, freq="D")
     df = pd.DataFrame({
         "date": dates,
-        "close": 10 + np.cumsum(np.random.randn(20)),
-        "sentiment": np.sin(np.linspace(0, 3, 20)),
+        "close": 10 + np.cumsum(np.random.randn(60)),
+        "sentiment": np.sin(np.linspace(0, 3, 60)),
     })
     acc, f1 = train_per_stock(df, n_splits=3)
     print(f"Accuracy: {acc:.3f}, F1: {f1:.3f}")
@@ -29,11 +29,11 @@ def test_train_per_stock_basic():
 
 def test_train_per_stock_random_forest():
     np.random.seed(1)
-    dates = pd.date_range("2024-01-01", periods=30, freq="D")
+    dates = pd.date_range("2024-01-01", periods=60, freq="D")
     df = pd.DataFrame({
         "date": dates,
-        "close": 20 + np.cumsum(np.random.randn(30)),
-        "sentiment": np.cos(np.linspace(0, 4, 30)),
+        "close": 20 + np.cumsum(np.random.randn(60)),
+        "sentiment": np.cos(np.linspace(0, 4, 60)),
     })
     acc, f1 = train_per_stock(df, n_splits=3, model_type="random_forest")
     assert acc is not None
@@ -49,3 +49,47 @@ def test_train_per_stock_insufficient_classes():
     })
     acc, f1 = train_per_stock(df)
     assert acc is None and f1 is None
+
+
+def test_train_per_stock_with_additional_features(monkeypatch):
+    np.random.seed(2)
+    dates = pd.date_range("2024-01-01", periods=80, freq="D")
+    df = pd.DataFrame(
+        {
+            "date": dates,
+            "open": 10 + np.cumsum(np.random.randn(80)),
+            "high": 10 + np.cumsum(np.random.randn(80)) + 1,
+            "low": 10 + np.cumsum(np.random.randn(80)) - 1,
+            "close": 10 + np.cumsum(np.random.randn(80)),
+            "volume": np.random.randint(100, 1000, size=80),
+            "sentiment": np.random.randn(80),
+        }
+    )
+
+    captured: dict[str, pd.DataFrame] = {}
+
+    class DummyGrid:
+        def __init__(self, *args, **kwargs):
+            self.best_index_ = 0
+            self.cv_results_ = {"mean_test_accuracy": [0.5], "mean_test_f1": [0.5]}
+            self.best_params_ = {}
+
+        def fit(self, X, y):
+            captured["X"] = X
+            return self
+
+    monkeypatch.setattr("wallenstein.models.GridSearchCV", DummyGrid)
+    acc, f1 = train_per_stock(df, n_splits=3)
+    assert acc is not None and f1 is not None
+
+    X = captured["X"]
+    expected = {
+        "Open_lag1",
+        "High_MA3",
+        "Low_STD7",
+        "Volume_lag2",
+        "RSI",
+        "MACD",
+        "BB_Upper",
+    }
+    assert expected.issubset(set(X.columns))

--- a/wallenstein/models.py
+++ b/wallenstein/models.py
@@ -48,7 +48,7 @@ def train_per_stock(
     # Convert sentiment to numeric and replace invalid entries with 0
     df["sentiment"] = pd.to_numeric(df["sentiment"], errors="coerce").fillna(0)
 
-    # Lagged features for close and sentiment
+    # Lagged and rolling features for mandatory columns
     df["Close_lag1"] = df["close"].shift(1)
     df["Close_lag2"] = df["close"].shift(2)
     df["Close_lag3"] = df["close"].shift(3)
@@ -56,7 +56,6 @@ def train_per_stock(
     df["Sentiment_lag2"] = df["sentiment"].shift(2)
     df["Sentiment_lag3"] = df["sentiment"].shift(3)
 
-    # Rolling features for close and sentiment
     df["Close_MA3"] = df["close"].rolling(window=3).mean().shift(1)
     df["Close_STD3"] = df["close"].rolling(window=3).std().shift(1)
     df["Sentiment_MA3"] = df["sentiment"].rolling(window=3).mean().shift(1)
@@ -66,12 +65,6 @@ def train_per_stock(
     df["Close_STD7"] = df["close"].rolling(window=7).std().shift(1)
     df["Sentiment_MA7"] = df["sentiment"].rolling(window=7).mean().shift(1)
     df["Sentiment_STD7"] = df["sentiment"].rolling(window=7).std().shift(1)
-
-    df["y"] = (df["close"] > df["Close_lag1"]).astype(int)
-    df.dropna(inplace=True)
-
-    if len(df) < 2:
-        return None, None
 
     features = [
         "Close_lag1",
@@ -89,6 +82,66 @@ def train_per_stock(
         "Sentiment_MA7",
         "Sentiment_STD7",
     ]
+
+    # Optional price-related columns
+    extra_cols = {
+        "open": "Open",
+        "high": "High",
+        "low": "Low",
+        "volume": "Volume",
+    }
+    for col, prefix in extra_cols.items():
+        if col in df.columns:
+            df[f"{prefix}_lag1"] = df[col].shift(1)
+            df[f"{prefix}_lag2"] = df[col].shift(2)
+            df[f"{prefix}_lag3"] = df[col].shift(3)
+            df[f"{prefix}_MA3"] = df[col].rolling(window=3).mean().shift(1)
+            df[f"{prefix}_STD3"] = df[col].rolling(window=3).std().shift(1)
+            df[f"{prefix}_MA7"] = df[col].rolling(window=7).mean().shift(1)
+            df[f"{prefix}_STD7"] = df[col].rolling(window=7).std().shift(1)
+            features.extend(
+                [
+                    f"{prefix}_lag1",
+                    f"{prefix}_lag2",
+                    f"{prefix}_lag3",
+                    f"{prefix}_MA3",
+                    f"{prefix}_STD3",
+                    f"{prefix}_MA7",
+                    f"{prefix}_STD7",
+                ]
+            )
+
+    # Technical indicators based on close price
+    delta = df["close"].diff()
+    gain = delta.clip(lower=0)
+    loss = -delta.clip(upper=0)
+    avg_gain = gain.rolling(window=14).mean()
+    avg_loss = loss.rolling(window=14).mean()
+    rs = avg_gain / avg_loss
+    df["RSI"] = (100 - (100 / (1 + rs))).shift(1)
+    features.append("RSI")
+
+    ema12 = df["close"].ewm(span=12, adjust=False).mean()
+    ema26 = df["close"].ewm(span=26, adjust=False).mean()
+    macd = ema12 - ema26
+    signal = macd.ewm(span=9, adjust=False).mean()
+    df["MACD"] = macd.shift(1)
+    df["MACD_Signal"] = signal.shift(1)
+    df["MACD_Hist"] = (macd - signal).shift(1)
+    features.extend(["MACD", "MACD_Signal", "MACD_Hist"])
+
+    bb_ma = df["close"].rolling(window=20).mean()
+    bb_std = df["close"].rolling(window=20).std()
+    df["BB_Middle"] = bb_ma.shift(1)
+    df["BB_Upper"] = (bb_ma + 2 * bb_std).shift(1)
+    df["BB_Lower"] = (bb_ma - 2 * bb_std).shift(1)
+    features.extend(["BB_Upper", "BB_Lower", "BB_Middle"])
+
+    df["y"] = (df["close"] > df["Close_lag1"]).astype(int)
+    df.dropna(inplace=True)
+
+    if len(df) < 2:
+        return None, None
 
     X = df[features]
     y = df["y"]

--- a/wallenstein/stock_data.py
+++ b/wallenstein/stock_data.py
@@ -16,7 +16,6 @@ Schreiben:
 from __future__ import annotations
 
 import io
-import json
 import logging
 import random
 import time
@@ -28,12 +27,13 @@ import pandas as pd
 import requests
 import yfinance as yf
 from requests.adapters import HTTPAdapter
-from requests.exceptions import HTTPError, RequestException
+from requests.exceptions import HTTPError
 from urllib3.util.retry import Retry
 
 # Optional: curl_cffi (robustere HTTP-Session gg. Blocks/429)
 try:
     from curl_cffi import requests as cffi_requests  # type: ignore
+
     HAVE_CURL_CFFI = True
 except Exception:  # pragma: no cover
     cffi_requests = None
@@ -61,8 +61,10 @@ log = logging.getLogger(__name__)
 # DuckDB Helpers
 # ------------------------------------------------------------------------------
 
+
 def _connect(db_path: str) -> duckdb.DuckDBPyConnection:
     return duckdb.connect(db_path)
+
 
 def _ensure_prices_table(con: duckdb.DuckDBPyConnection):
     # Wenn 'prices' als VIEW existiert: droppen
@@ -99,6 +101,7 @@ def _ensure_prices_table(con: duckdb.DuckDBPyConnection):
     except Exception:
         pass  # ältere DuckDBs ohne Indexunterstützung
 
+
 def _latest_dates_per_ticker(
     con: duckdb.DuckDBPyConnection, tickers: list[str]
 ) -> dict[str, date | None]:
@@ -109,7 +112,9 @@ def _latest_dates_per_ticker(
         FROM prices
         WHERE ticker IN ({})
         GROUP BY ticker
-    """.format(", ".join("'" + t + "'" for t in tickers))
+    """.format(
+        ", ".join("'" + t + "'" for t in tickers)
+    )
     try:
         df = con.execute(q).fetchdf()
         m = {row["ticker"]: row["last_date"] for _, row in df.iterrows()}
@@ -118,17 +123,21 @@ def _latest_dates_per_ticker(
         log.debug(f"_latest_dates_per_ticker: query failed: {e}")
         return {}
 
+
 def _retry_sleep(attempt: int):
     # exponentiell + Jitter
     time.sleep((2**attempt) + random.random())
+
 
 # ------------------------------------------------------------------------------
 # Stooq (CSV)
 # ------------------------------------------------------------------------------
 
+
 def _stooq_symbol(t: str) -> str:
     # Stooq erwartet z.B. nvda.us, amzn.us
     return f"{t.lower()}.us"
+
 
 def _stooq_fetch_one(
     ticker: str, start: pd.Timestamp | None = None, session: requests.Session | None = None
@@ -145,8 +154,14 @@ def _stooq_fetch_one(
             if df.empty:
                 raise RuntimeError("stooq empty dataframe")
             df = df.rename(
-                columns={"Date": "date", "Open": "open", "High": "high",
-                         "Low": "low", "Close": "close", "Volume": "volume"}
+                columns={
+                    "Date": "date",
+                    "Open": "open",
+                    "High": "high",
+                    "Low": "low",
+                    "Close": "close",
+                    "Volume": "volume",
+                }
             )
             df["ticker"] = ticker
             df["date"] = pd.to_datetime(df["date"]).dt.date
@@ -158,13 +173,18 @@ def _stooq_fetch_one(
         except Exception as e:
             log.debug(f"Stooq {_stooq_symbol(ticker)} attempt#{attempt+1} failed: {e}")
             _retry_sleep(attempt)
-    return pd.DataFrame(columns=["date","ticker","open","high","low","close","adj_close","volume"])
+    return pd.DataFrame(
+        columns=["date", "ticker", "open", "high", "low", "close", "adj_close", "volume"]
+    )
+
 
 def _stooq_fetch_many(
     tickers: list[str], start_map: dict[str, pd.Timestamp] | None = None
 ) -> pd.DataFrame:
     if not tickers:
-        return pd.DataFrame(columns=["date","ticker","open","high","low","close","adj_close","volume"])
+        return pd.DataFrame(
+            columns=["date", "ticker", "open", "high", "low", "close", "adj_close", "volume"]
+        )
     results: list[pd.DataFrame] = []
 
     def _fetch(t: str) -> pd.DataFrame:
@@ -178,12 +198,16 @@ def _stooq_fetch_many(
             if not df.empty:
                 results.append(df)
     if not results:
-        return pd.DataFrame(columns=["date","ticker","open","high","low","close","adj_close","volume"])
+        return pd.DataFrame(
+            columns=["date", "ticker", "open", "high", "low", "close", "adj_close", "volume"]
+        )
     return pd.concat(results, ignore_index=True)
+
 
 # ------------------------------------------------------------------------------
 # HTTP Sessions
 # ------------------------------------------------------------------------------
+
 
 def _make_session(user_agent: str | None = None):
     """
@@ -191,22 +215,26 @@ def _make_session(user_agent: str | None = None):
     """
     if HAVE_CURL_CFFI:
         s = cffi_requests.Session(impersonate="chrome")
-        s.headers.update({
+        s.headers.update(
+            {
+                "User-Agent": user_agent or settings.YF_USER_AGENT,
+                "Accept": "*/*",
+                "Accept-Language": "en-US,en;q=0.9,de-DE;q=0.8",
+                "Connection": "keep-alive",
+                "Referer": "https://finance.yahoo.com/",
+            }
+        )
+        return s
+    s = requests.Session()
+    s.headers.update(
+        {
             "User-Agent": user_agent or settings.YF_USER_AGENT,
             "Accept": "*/*",
             "Accept-Language": "en-US,en;q=0.9,de-DE;q=0.8",
             "Connection": "keep-alive",
             "Referer": "https://finance.yahoo.com/",
-        })
-        return s
-    s = requests.Session()
-    s.headers.update({
-        "User-Agent": user_agent or settings.YF_USER_AGENT,
-        "Accept": "*/*",
-        "Accept-Language": "en-US,en;q=0.9,de-DE;q=0.8",
-        "Connection": "keep-alive",
-        "Referer": "https://finance.yahoo.com/",
-    })
+        }
+    )
     retry = Retry(
         total=MAX_RETRIES,
         backoff_factor=1.0,
@@ -219,9 +247,11 @@ def _make_session(user_agent: str | None = None):
     s.mount("http://", adapter)
     return s
 
+
 # ------------------------------------------------------------------------------
 # Yahoo Chart API (JSON)
 # ------------------------------------------------------------------------------
+
 
 def _chart_api_get_raw(ticker: str, params: dict, session) -> dict | None:
     """Fragt query2/query1 chart v8 ab und liefert einen einzelnen 'result'-Eintrag."""
@@ -229,8 +259,7 @@ def _chart_api_get_raw(ticker: str, params: dict, session) -> dict | None:
         url = f"https://{host}/v8/finance/chart/{ticker}"
         try:
             r = session.get(
-                url, params=params, timeout=20,
-                headers={"Referer": "https://finance.yahoo.com/"}
+                url, params=params, timeout=20, headers={"Referer": "https://finance.yahoo.com/"}
             )
             if not r.ok:
                 log.debug(f"{ticker}: chart API {host} status={r.status_code} params={params}")
@@ -250,6 +279,7 @@ def _chart_api_get_raw(ticker: str, params: dict, session) -> dict | None:
             continue
     return None
 
+
 def _yahoo_chart_api_daily(ticker: str, session) -> pd.DataFrame:
     """
     Holt gestern+heute als Daily-Bars (range=2d, interval=1d).
@@ -257,21 +287,29 @@ def _yahoo_chart_api_daily(ticker: str, session) -> pd.DataFrame:
     params = {"range": "2d", "interval": "1d", "includePrePost": "true", "events": "div,splits"}
     out = _chart_api_get_raw(ticker, params, session)
     if not out:
-        return pd.DataFrame(columns=["date","ticker","open","high","low","close","adj_close","volume"])
+        return pd.DataFrame(
+            columns=["date", "ticker", "open", "high", "low", "close", "adj_close", "volume"]
+        )
     ts = out.get("timestamp") or []
     q = (out.get("indicators", {}) or {}).get("quote", [{}])[0]
     if not ts or not q:
-        return pd.DataFrame(columns=["date","ticker","open","high","low","close","adj_close","volume"])
-    df = pd.DataFrame({
-        "dt": pd.to_datetime(ts, unit="s", utc=True),
-        "open":  q.get("open"),
-        "high":  q.get("high"),
-        "low":   q.get("low"),
-        "close": q.get("close"),
-        "volume": q.get("volume"),
-    }).dropna(subset=["open","high","low","close"], how="all")
+        return pd.DataFrame(
+            columns=["date", "ticker", "open", "high", "low", "close", "adj_close", "volume"]
+        )
+    df = pd.DataFrame(
+        {
+            "dt": pd.to_datetime(ts, unit="s", utc=True),
+            "open": q.get("open"),
+            "high": q.get("high"),
+            "low": q.get("low"),
+            "close": q.get("close"),
+            "volume": q.get("volume"),
+        }
+    ).dropna(subset=["open", "high", "low", "close"], how="all")
     if df.empty:
-        return pd.DataFrame(columns=["date","ticker","open","high","low","close","adj_close","volume"])
+        return pd.DataFrame(
+            columns=["date", "ticker", "open", "high", "low", "close", "adj_close", "volume"]
+        )
     try:
         df["dt"] = df["dt"].dt.tz_convert(None)
     except Exception:
@@ -279,23 +317,26 @@ def _yahoo_chart_api_daily(ticker: str, session) -> pd.DataFrame:
     df["date"] = df["dt"].dt.date
     df["ticker"] = ticker
     df["adj_close"] = pd.NA
-    return df[["date","ticker","open","high","low","close","adj_close","volume"]]
+    return df[["date", "ticker", "open", "high", "low", "close", "adj_close", "volume"]]
+
 
 def _chart_result_to_intraday_df(ticker: str, out: dict) -> pd.DataFrame:
     if not out:
-        return pd.DataFrame(columns=["dt","open","high","low","close","volume"])
+        return pd.DataFrame(columns=["dt", "open", "high", "low", "close", "volume"])
     ts = out.get("timestamp") or []
     q = (out.get("indicators", {}) or {}).get("quote", [{}])[0]
     if not ts or not q:
-        return pd.DataFrame(columns=["dt","open","high","low","close","volume"])
-    df = pd.DataFrame({
-        "dt": pd.to_datetime(ts, unit="s", utc=True),
-        "open":  q.get("open"),
-        "high":  q.get("high"),
-        "low":   q.get("low"),
-        "close": q.get("close"),
-        "volume": q.get("volume"),
-    }).dropna(subset=["open","high","low","close"], how="all")
+        return pd.DataFrame(columns=["dt", "open", "high", "low", "close", "volume"])
+    df = pd.DataFrame(
+        {
+            "dt": pd.to_datetime(ts, unit="s", utc=True),
+            "open": q.get("open"),
+            "high": q.get("high"),
+            "low": q.get("low"),
+            "close": q.get("close"),
+            "volume": q.get("volume"),
+        }
+    ).dropna(subset=["open", "high", "low", "close"], how="all")
     if df.empty:
         return df
     try:
@@ -303,6 +344,7 @@ def _chart_result_to_intraday_df(ticker: str, out: dict) -> pd.DataFrame:
     except Exception:
         df["dt"] = df["dt"].dt.tz_localize(None)
     return df
+
 
 def _yahoo_chart_api_intraday_to_daily(
     ticker: str,
@@ -342,23 +384,36 @@ def _yahoo_chart_api_intraday_to_daily(
 
             o = float(dft["open"].iloc[0])
             h = float(pd.to_numeric(dft["high"], errors="coerce").max())
-            l = float(pd.to_numeric(dft["low"],  errors="coerce").min())
+            low_val = float(pd.to_numeric(dft["low"], errors="coerce").min())
             c = float(dft["close"].iloc[-1])
             v = int(pd.to_numeric(dft["volume"], errors="coerce").fillna(0).sum())
 
-            outdf = pd.DataFrame([{
-                "date": today, "ticker": ticker,
-                "open": o, "high": h, "low": l, "close": c,
-                "adj_close": pd.NA, "volume": v
-            }])
+            outdf = pd.DataFrame(
+                [
+                    {
+                        "date": today,
+                        "ticker": ticker,
+                        "open": o,
+                        "high": h,
+                        "low": low_val,
+                        "close": c,
+                        "adj_close": pd.NA,
+                        "volume": v,
+                    }
+                ]
+            )
             log.debug(f"{ticker}: intraday OK range={rng} interval={iv} rows={len(dft)}")
             return outdf
 
-    return pd.DataFrame(columns=["date","ticker","open","high","low","close","adj_close","volume"])
+    return pd.DataFrame(
+        columns=["date", "ticker", "open", "high", "low", "close", "adj_close", "volume"]
+    )
+
 
 # ------------------------------------------------------------------------------
 # Yahoo Download (safe, mehrstufig)
 # ------------------------------------------------------------------------------
+
 
 def _download_single_safe(
     ticker: str,
@@ -372,21 +427,31 @@ def _download_single_safe(
       2) yfinance history (raise_errors=False)
       3) yfinance 2d/1d
     """
+
     def _empty() -> pd.DataFrame:
-        return pd.DataFrame(columns=["date","ticker","open","high","low","close","adj_close","volume"])
+        return pd.DataFrame(
+            columns=["date", "ticker", "open", "high", "low", "close", "adj_close", "volume"]
+        )
 
     def _norm(df_hist: pd.DataFrame) -> pd.DataFrame:
         if df_hist is None or df_hist.empty:
             return _empty()
         df = df_hist.reset_index().rename(columns={"Date": "date"})
         df["ticker"] = ticker
-        colmap = {"Open":"open","High":"high","Low":"low","Close":"close","Adj Close":"adj_close","Volume":"volume"}
-        df.rename(columns={k:v for k,v in colmap.items() if k in df.columns}, inplace=True)
-        for c in ("adj_close","volume"):
+        colmap = {
+            "Open": "open",
+            "High": "high",
+            "Low": "low",
+            "Close": "close",
+            "Adj Close": "adj_close",
+            "Volume": "volume",
+        }
+        df.rename(columns={k: v for k, v in colmap.items() if k in df.columns}, inplace=True)
+        for c in ("adj_close", "volume"):
             if c not in df.columns:
                 df[c] = pd.NA
         df["date"] = pd.to_datetime(df["date"]).dt.date
-        return df[["date","ticker","open","high","low","close","adj_close","volume"]]
+        return df[["date", "ticker", "open", "high", "low", "close", "adj_close", "volume"]]
 
     today_utc = pd.Timestamp.utcnow().date()
     last_err: Exception | None = None
@@ -411,13 +476,21 @@ def _download_single_safe(
                 use_period = "7d"
             if use_start is not None:
                 hist = tk.history(
-                    start=use_start, interval="1d",
-                    auto_adjust=False, actions=False, timeout=30, raise_errors=False
+                    start=use_start,
+                    interval="1d",
+                    auto_adjust=False,
+                    actions=False,
+                    timeout=30,
+                    raise_errors=False,
                 )
             else:
                 hist = tk.history(
-                    period=use_period, interval="1d",
-                    auto_adjust=False, actions=False, timeout=30, raise_errors=False
+                    period=use_period,
+                    interval="1d",
+                    auto_adjust=False,
+                    actions=False,
+                    timeout=30,
+                    raise_errors=False,
                 )
             df = _norm(hist)
             if not df.empty:
@@ -426,8 +499,12 @@ def _download_single_safe(
 
             # (3) yfinance 2d/1d
             hist2 = tk.history(
-                period="2d", interval="1d",
-                auto_adjust=False, actions=False, timeout=30, raise_errors=False
+                period="2d",
+                interval="1d",
+                auto_adjust=False,
+                actions=False,
+                timeout=30,
+                raise_errors=False,
             )
             df2 = _norm(hist2)
             if not df2.empty:
@@ -440,6 +517,7 @@ def _download_single_safe(
         except HTTPError as e:
             status = e.response.status_code if e.response is not None else None
             if status == 429:
+                log.warning(f"{ticker}: skipped due to rate limiting")
                 return _empty()
             last_err = e
             log.debug(f"{ticker}: HTTPError on attempt {attempt+1}: {e}")
@@ -463,6 +541,7 @@ def _download_single_safe(
         log.warning(f"{ticker}: network error ({last_err.__class__.__name__})")
     return _empty()
 
+
 def _yahoo_fetch_many(
     tickers: list[str],
     start_map: dict[str, pd.Timestamp] | None = None,
@@ -472,7 +551,13 @@ def _yahoo_fetch_many(
     results: list[pd.DataFrame] = []
     with ThreadPoolExecutor(max_workers=min(YAHOO_MAX_WORKERS, len(tickers))) as ex:
         futures = {
-            ex.submit(_download_single_safe, t, sess, start=start_map.get(t) if start_map else None, period="1mo"): t
+            ex.submit(
+                _download_single_safe,
+                t,
+                sess,
+                start=start_map.get(t) if start_map else None,
+                period="1mo",
+            ): t
             for t in tickers
         }
         for fut in as_completed(futures):
@@ -480,12 +565,16 @@ def _yahoo_fetch_many(
             if df is not None and not df.empty:
                 results.append(df)
     if not results:
-        return pd.DataFrame(columns=["date","ticker","open","high","low","close","adj_close","volume"])
+        return pd.DataFrame(
+            columns=["date", "ticker", "open", "high", "low", "close", "adj_close", "volume"]
+        )
     return pd.concat(results, ignore_index=True)
+
 
 # ------------------------------------------------------------------------------
 # Public API
 # ------------------------------------------------------------------------------
+
 
 def update_prices(db_path: str, tickers: list[str]) -> int:
     """
@@ -526,16 +615,17 @@ def update_prices(db_path: str, tickers: list[str]) -> int:
             start_map[t] = pd.Timestamp(ld) + pd.Timedelta(days=1)
         else:
             start_map[t] = None
-    log.debug("start_map: %s", {k: (str(v.date()) if v is not None else None) for k, v in start_map.items()})
+    log.debug(
+        "start_map: %s",
+        {k: (str(v.date()) if v is not None else None) for k, v in start_map.items()},
+    )
 
     all_rows: list[pd.DataFrame] = []
 
     for i in range(0, len(tickers), CHUNK_SIZE):
         chunk = tickers[i : i + CHUNK_SIZE]
         chunk_valid = [
-            t
-            for t in chunk
-            if start_map.get(t) is None or start_map[t].date() <= last_trading_day
+            t for t in chunk if start_map.get(t) is None or start_map[t].date() <= last_trading_day
         ]
         if not chunk_valid:
             continue
@@ -544,13 +634,17 @@ def update_prices(db_path: str, tickers: list[str]) -> int:
         # --- Primärquelle ---
         if DATA_SOURCE == "yahoo":
             df_chunk = _yahoo_fetch_many(chunk_valid, start_map=start_map, session=session)
-            log.debug("primary=yahoo rows=%s tickers=%s",
-                      0 if df_chunk is None or df_chunk.empty else len(df_chunk),
-                      [] if df_chunk is None or df_chunk.empty else sorted(df_chunk['ticker'].unique()))
+            log.debug(
+                "primary=yahoo rows=%s tickers=%s",
+                0 if df_chunk is None or df_chunk.empty else len(df_chunk),
+                [] if df_chunk is None or df_chunk.empty else sorted(df_chunk["ticker"].unique()),
+            )
             # Fallback Stooq für Ticker ohne Zeilen
-            missing = chunk_valid if df_chunk is None or df_chunk.empty else [
-                t for t in chunk_valid if df_chunk[df_chunk["ticker"].eq(t)].empty
-            ]
+            missing = (
+                chunk_valid
+                if df_chunk is None or df_chunk.empty
+                else [t for t in chunk_valid if df_chunk[df_chunk["ticker"].eq(t)].empty]
+            )
             if missing:
                 log.debug("fallback stooq for: %s", missing)
                 df_fb = _stooq_fetch_many(missing, start_map=start_map)
@@ -558,17 +652,27 @@ def update_prices(db_path: str, tickers: list[str]) -> int:
                     df_chunk = df_fb
                 elif df_fb is not None and not df_fb.empty:
                     df_chunk = pd.concat([df_chunk, df_fb], ignore_index=True)
-                log.debug("after fallback rows=%s tickers=%s",
-                          0 if df_chunk is None or df_chunk.empty else len(df_chunk),
-                          [] if df_chunk is None or df_chunk.empty else sorted(df_chunk['ticker'].unique()))
+                log.debug(
+                    "after fallback rows=%s tickers=%s",
+                    0 if df_chunk is None or df_chunk.empty else len(df_chunk),
+                    (
+                        []
+                        if df_chunk is None or df_chunk.empty
+                        else sorted(df_chunk["ticker"].unique())
+                    ),
+                )
         else:
             df_chunk = _stooq_fetch_many(chunk_valid, start_map=start_map)
-            log.debug("primary=stooq rows=%s tickers=%s",
-                      0 if df_chunk is None or df_chunk.empty else len(df_chunk),
-                      [] if df_chunk is None or df_chunk.empty else sorted(df_chunk['ticker'].unique()))
-            missing = chunk_valid if df_chunk is None or df_chunk.empty else [
-                t for t in chunk_valid if df_chunk[df_chunk["ticker"].eq(t)].empty
-            ]
+            log.debug(
+                "primary=stooq rows=%s tickers=%s",
+                0 if df_chunk is None or df_chunk.empty else len(df_chunk),
+                [] if df_chunk is None or df_chunk.empty else sorted(df_chunk["ticker"].unique()),
+            )
+            missing = (
+                chunk_valid
+                if df_chunk is None or df_chunk.empty
+                else [t for t in chunk_valid if df_chunk[df_chunk["ticker"].eq(t)].empty]
+            )
             if missing:
                 log.debug("fallback yahoo for: %s", missing)
                 df_fb = _yahoo_fetch_many(missing, start_map=start_map, session=session)
@@ -576,9 +680,15 @@ def update_prices(db_path: str, tickers: list[str]) -> int:
                     df_chunk = df_fb
                 elif df_fb is not None and not df_fb.empty:
                     df_chunk = pd.concat([df_chunk, df_fb], ignore_index=True)
-                log.debug("after fallback rows=%s tickers=%s",
-                          0 if df_chunk is None or df_chunk.empty else len(df_chunk),
-                          [] if df_chunk is None or df_chunk.empty else sorted(df_chunk['ticker'].unique()))
+                log.debug(
+                    "after fallback rows=%s tickers=%s",
+                    0 if df_chunk is None or df_chunk.empty else len(df_chunk),
+                    (
+                        []
+                        if df_chunk is None or df_chunk.empty
+                        else sorted(df_chunk["ticker"].unique())
+                    ),
+                )
 
         # Wenn immer noch nichts da: Intraday->Daily für den ganzen Chunk
         if df_chunk is None or df_chunk.empty:
@@ -605,12 +715,14 @@ def update_prices(db_path: str, tickers: list[str]) -> int:
             ld = last_map.get(t)
             if pd.notna(ld):
                 ld_d = pd.to_datetime(ld).date()
-                mask_new = (pd.to_datetime(df_t["date"]).dt.date > ld_d)
+                mask_new = pd.to_datetime(df_t["date"]).dt.date > ld_d
                 if REFRESH_SAME_DAY and ld_d == last_trading_day:
                     mask_new = mask_new | (pd.to_datetime(df_t["date"]).dt.date == last_trading_day)
                 df_t = df_t[mask_new]
             if not df_t.empty:
-                all_rows.append(df_t[["date","ticker","open","high","low","close","adj_close","volume"]])
+                all_rows.append(
+                    df_t[["date", "ticker", "open", "high", "low", "close", "adj_close", "volume"]]
+                )
                 updated_tickers.append(t)
 
         log.debug("tickers with new/refresh rows in chunk: %s", updated_tickers)
@@ -626,7 +738,7 @@ def update_prices(db_path: str, tickers: list[str]) -> int:
 
     df_all = pd.concat(all_rows, ignore_index=True)
     df_all["date"] = pd.to_datetime(df_all["date"]).dt.date
-    df_all = df_all.sort_values(["ticker","date"]).dropna(subset=["date","ticker"])
+    df_all = df_all.sort_values(["ticker", "date"]).dropna(subset=["date", "ticker"])
 
     # Validierung
     validate_df(df_all, "prices")
@@ -637,7 +749,8 @@ def update_prices(db_path: str, tickers: list[str]) -> int:
 
     # Upsert: MERGE (wenn möglich) -> sonst DELETE+INSERT
     try:
-        con.execute("""
+        con.execute(
+            """
             MERGE INTO prices AS p
             USING tmp_prices AS d
             ON p.date = d.date AND p.ticker = d.ticker
@@ -646,19 +759,24 @@ def update_prices(db_path: str, tickers: list[str]) -> int:
                 adj_close = d.adj_close, volume = d.volume
             WHEN NOT MATCHED THEN INSERT (date, ticker, open, high, low, close, adj_close, volume)
             VALUES (d.date, d.ticker, d.open, d.high, d.low, d.close, d.adj_close, d.volume)
-        """)
+        """
+        )
         log.debug("UPSERT via MERGE successful.")
     except Exception as e:
-        log.warning(f"MERGE not supported/failed ({e.__class__.__name__}): fallback to DELETE+INSERT.")
+        log.warning(
+            f"MERGE not supported/failed ({e.__class__.__name__}): fallback to DELETE+INSERT."
+        )
         con.execute("BEGIN")
-        con.execute("""
+        con.execute(
+            """
             DELETE FROM prices
             WHERE EXISTS (
                 SELECT 1 FROM tmp_prices d
                 WHERE d.date = prices.date
                   AND d.ticker = prices.ticker
             )
-        """)
+        """
+        )
         con.execute("INSERT INTO prices SELECT * FROM tmp_prices")
         con.execute("COMMIT")
         log.debug("UPSERT via DELETE+INSERT done.")
@@ -672,9 +790,11 @@ def update_prices(db_path: str, tickers: list[str]) -> int:
     log.info("Kursdaten aktualisiert/aktualisiert: +%s Zeilen", n)
     return n
 
+
 # ------------------------------------------------------------------------------
 # FX: EURUSD via Stooq
 # ------------------------------------------------------------------------------
+
 
 def _ensure_fx_table(con: duckdb.DuckDBPyConnection):
     con.execute(
@@ -688,12 +808,14 @@ def _ensure_fx_table(con: duckdb.DuckDBPyConnection):
         """
     )
 
+
 def _fx_latest_date(con: duckdb.DuckDBPyConnection, pair: str):
     try:
         row = con.execute("SELECT max(date) FROM fx_rates WHERE pair = ?", [pair]).fetchone()
         return row[0]
     except Exception:
         return None
+
 
 def _stooq_fetch_fx_eurusd(start: pd.Timestamp | None = None) -> pd.DataFrame:
     url = "https://stooq.com/q/d/l/?s=eurusd&i=d"
@@ -711,10 +833,11 @@ def _stooq_fetch_fx_eurusd(start: pd.Timestamp | None = None) -> pd.DataFrame:
             df = df[df["date"] >= start_d]
         df["pair"] = "EURUSD"
         df["rate_usd_per_eur"] = pd.to_numeric(df["close"], errors="coerce")
-        return df[["date","pair","rate_usd_per_eur"]].dropna()
+        return df[["date", "pair", "rate_usd_per_eur"]].dropna()
     except Exception as e:
         log.debug(f"stooq EURUSD failed: {e}")
         return pd.DataFrame()
+
 
 def update_fx_rates(db_path: str) -> int:
     con = _connect(db_path)
@@ -729,31 +852,35 @@ def update_fx_rates(db_path: str) -> int:
         log.info("FX-Update: keine neuen EURUSD-Zeilen")
         return 0
 
-    df = df.sort_values("date").drop_duplicates(subset=["date","pair"])
+    df = df.sort_values("date").drop_duplicates(subset=["date", "pair"])
     con.execute("CREATE TEMP TABLE tmp_fx AS SELECT * FROM df")
 
     # Upsert mit MERGE, Fallback DELETE+INSERT
     try:
-        con.execute("""
+        con.execute(
+            """
             MERGE INTO fx_rates AS f
             USING tmp_fx AS d
             ON f.date = d.date AND f.pair = d.pair
             WHEN MATCHED THEN UPDATE SET rate_usd_per_eur = d.rate_usd_per_eur
             WHEN NOT MATCHED THEN INSERT (date, pair, rate_usd_per_eur)
             VALUES (d.date, d.pair, d.rate_usd_per_eur)
-        """)
+        """
+        )
         log.debug("FX UPSERT via MERGE successful.")
     except Exception as e:
         log.warning(f"FX MERGE not supported/failed ({e.__class__.__name__}) -> DELETE+INSERT.")
         con.execute("BEGIN")
-        con.execute("""
+        con.execute(
+            """
             DELETE FROM fx_rates
             WHERE EXISTS (
                 SELECT 1 FROM tmp_fx d
                 WHERE d.date = fx_rates.date
                   AND d.pair = fx_rates.pair
             )
-        """)
+        """
+        )
         con.execute("INSERT INTO fx_rates SELECT * FROM tmp_fx")
         con.execute("COMMIT")
         log.debug("FX UPSERT via DELETE+INSERT done.")


### PR DESCRIPTION
## Summary
- extend training to use Open, High, Low and Volume when present
- compute RSI, MACD and Bollinger Band indicators as additional features
- cover new feature set with updated tests and warn on Yahoo rate limiting

## Testing
- `pre-commit run --files wallenstein/models.py wallenstein/stock_data.py tests/test_models.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af57046e948325ba93e5fb65ce05e5