### PR TITLE
Add evaluation metrics and backtesting

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,14 +1,14 @@
 import sys
 from pathlib import Path
 
-import pandas as pd
 import numpy as np
+import pandas as pd
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from wallenstein.models import train_per_stock
+from wallenstein.models import backtest_strategy, train_per_stock
 
 
 def test_train_per_stock_basic():
@@ -19,12 +19,17 @@ def test_train_per_stock_basic():
         "close": 10 + np.cumsum(np.random.randn(20)),
         "sentiment": np.sin(np.linspace(0, 3, 20)),
     })
-    acc, f1 = train_per_stock(df, n_splits=3)
-    print(f"Accuracy: {acc:.3f}, F1: {f1:.3f}")
-    assert acc is not None
-    assert f1 is not None
+    acc, f1, roc_auc, precision, recall = train_per_stock(df, n_splits=3)
+    print(
+        f"Accuracy: {acc:.3f}, F1: {f1:.3f}, ROC-AUC: {roc_auc:.3f},"
+        f" Precision: {precision:.3f}, Recall: {recall:.3f}"
+    )
+    assert acc is not None and f1 is not None
+    assert roc_auc is not None and 0.0 <= roc_auc <= 1.0
     assert 0.0 <= acc <= 1.0
     assert 0.0 <= f1 <= 1.0
+    assert 0.0 <= precision <= 1.0
+    assert 0.0 <= recall <= 1.0
 
 
 def test_train_per_stock_random_forest():
@@ -35,9 +40,12 @@ def test_train_per_stock_random_forest():
         "close": 20 + np.cumsum(np.random.randn(30)),
         "sentiment": np.cos(np.linspace(0, 4, 30)),
     })
-    acc, f1 = train_per_stock(df, n_splits=3, model_type="random_forest")
+    acc, f1, roc_auc, precision, recall = train_per_stock(
+        df, n_splits=3, model_type="random_forest"
+    )
     assert acc is not None
     assert f1 is not None
+    assert roc_auc is not None
 
 
 def test_train_per_stock_insufficient_classes():
@@ -47,5 +55,18 @@ def test_train_per_stock_insufficient_classes():
         "close": [1, 1, 1, 1, 1],  # no variation -> only one class
         "sentiment": [0, 0, 0, 0, 0],
     })
-    acc, f1 = train_per_stock(df)
-    assert acc is None and f1 is None
+    acc, f1, roc_auc, precision, recall = train_per_stock(df)
+    assert all(m is None for m in [acc, f1, roc_auc, precision, recall])
+
+
+def test_backtest_strategy():
+    df = pd.DataFrame(
+        {
+            "close": [10, 11, 12, 11],
+        }
+    )
+    signals = pd.Series([1, 0, 1, 0])
+    avg = backtest_strategy(df, signals)
+    # Returns: 1/10 and -1/12 -> average is 1/120
+    expected = (1 / 10 - 1 / 12) / 2
+    assert abs(avg - expected) < 1e-6


### PR DESCRIPTION
## Summary
- extend `train_per_stock` to compute ROC-AUC, precision, recall and run a simple backtest
- log per-stock metrics in the pipeline
- cover new metrics and backtest with tests

## Testing
- `ruff check wallenstein/models.py main.py tests/test_models.py`
- `pytest tests/test_models.py -q`
- `pytest -q` *(fails: tests/test_stock_data.py::test_download_single_safe_handles_429)*

------
https://chatgpt.com/codex/tasks/task_e_68af570a395483259cd22a4b9efd75a0