### PR TITLE
Add SVM and optional XGBoost models

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,16 @@ Supported models:
 - Logistic Regression
 - Random Forest
 - Gradient Boosting
+- Support Vector Machine
+- XGBoost (optional, requires ``pip install xgboost``)
+
+Select a model via ``model_type`` when calling ``train_per_stock``:
+
+```python
+from wallenstein.models import train_per_stock
+
+acc, f1 = train_per_stock(df, model_type="svm")
+```
 
 Example cross-validated scores on a synthetic 80-day dataset:
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pandas as pd
 import numpy as np
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -36,6 +37,33 @@ def test_train_per_stock_random_forest():
         "sentiment": np.cos(np.linspace(0, 4, 30)),
     })
     acc, f1 = train_per_stock(df, n_splits=3, model_type="random_forest")
+    assert acc is not None
+    assert f1 is not None
+
+
+def test_train_per_stock_svm():
+    np.random.seed(2)
+    dates = pd.date_range("2024-01-01", periods=30, freq="D")
+    df = pd.DataFrame({
+        "date": dates,
+        "close": 15 + np.cumsum(np.random.randn(30)),
+        "sentiment": np.sin(np.linspace(0, 4, 30)),
+    })
+    acc, f1 = train_per_stock(df, n_splits=3, model_type="svm")
+    assert acc is not None
+    assert f1 is not None
+
+
+def test_train_per_stock_xgboost():
+    pytest.importorskip("xgboost")
+    np.random.seed(3)
+    dates = pd.date_range("2024-01-01", periods=30, freq="D")
+    df = pd.DataFrame({
+        "date": dates,
+        "close": 25 + np.cumsum(np.random.randn(30)),
+        "sentiment": np.cos(np.linspace(0, 4, 30)),
+    })
+    acc, f1 = train_per_stock(df, n_splits=3, model_type="xgboost")
     assert acc is not None
     assert f1 is not None
 


### PR DESCRIPTION
## Summary
- add SVM and XGBoost options with hyperparameter grids in `train_per_stock`
- document how to select new models and note optional XGBoost dependency
- cover SVM and XGBoost paths with tests

## Testing
- `pre-commit run --files wallenstein/models.py tests/test_models.py README.md`
- `pytest` *(fails: AssertionError in tests/test_stock_data.py::test_download_single_safe_handles_429)*
- `pytest tests/test_models.py`

------
https://chatgpt.com/codex/tasks/task_e_68af5707318c83258fe1b1cb2ad01d25