### PR TITLE
feat: add search method options

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,8 @@ contains trained weights.
 The price movement model now uses a richer feature set including multiple
 lags for ``close`` and ``sentiment`` as well as 3/7-day moving averages and
 volatility measures. K-fold cross validation (5-fold) is enabled by default and
-GridSearchCV tunes hyperparameters for each supported model.
+hyperparameters can be tuned via ``GridSearchCV``, ``RandomizedSearchCV`` or
+``Optuna`` using the ``search_method`` parameter.
 
 Supported models:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ python-dotenv
 praw
 scikit-learn
 pyyaml
+optuna
+optuna-integration[sklearn]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -40,6 +40,32 @@ def test_train_per_stock_random_forest():
     assert f1 is not None
 
 
+def test_train_per_stock_random_search():
+    np.random.seed(2)
+    dates = pd.date_range("2024-01-01", periods=25, freq="D")
+    df = pd.DataFrame({
+        "date": dates,
+        "close": 15 + np.cumsum(np.random.randn(25)),
+        "sentiment": np.linspace(-1, 1, 25),
+    })
+    acc, f1 = train_per_stock(df, n_splits=3, search_method="random")
+    assert acc is not None
+    assert f1 is not None
+
+
+def test_train_per_stock_optuna_search():
+    np.random.seed(3)
+    dates = pd.date_range("2024-01-01", periods=25, freq="D")
+    df = pd.DataFrame({
+        "date": dates,
+        "close": 12 + np.cumsum(np.random.randn(25)),
+        "sentiment": np.cos(np.linspace(0, 3, 25)),
+    })
+    acc, f1 = train_per_stock(df, n_splits=3, search_method="optuna")
+    assert acc is not None
+    assert f1 is not None
+
+
 def test_train_per_stock_insufficient_classes():
     dates = pd.date_range("2024-01-01", periods=5, freq="D")
     df = pd.DataFrame({


### PR DESCRIPTION
## Summary
- add configurable `search_method` for grid, random, or Optuna tuning
- extend hyperparameter ranges for randomized and Optuna searches
- cover random and Optuna strategies with new tests

## Testing
- `pip install optuna`
- `pip install 'optuna-integration[sklearn]'`
- `pytest tests/test_models.py`


------
https://chatgpt.com/codex/tasks/task_e_68af570833e48325ab6216059f3cdb05