### PR TITLE
chore: remove legacy price helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 - `wallenstein.sentiment` now supports `SENTIMENT_BACKEND=finetuned-finbert`.
 - `scripts/evaluate_sentiment.py` evaluates keyword, baseline FinBERT and fine-tuned FinBERT models.
 - Added placeholder directory `models/finetuned-finbert` for trained weights.
+- Removed deprecated functions `_select_latest_prices` and `get_latest_prices_auto` from `wallenstein.db_utils`.


### PR DESCRIPTION
## Summary
- remove deprecated `_select_latest_prices` and `get_latest_prices_auto`
- document removal in changelog

## Testing
- `pre-commit run --files wallenstein/db_utils.py CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_68af5cd96d1483259bc2d53bea95afff