### PR TITLE
refactor: remove unused ticker matcher

### DIFF
--- a/wallenstein/reddit_scraper.py
+++ b/wallenstein/reddit_scraper.py
@@ -242,15 +242,6 @@ def _compile_patterns(ticker: str) -> list[re.Pattern]:
     return patterns
 
 
-def _post_matches_ticker(title: str, body: str, patterns: list[re.Pattern]) -> bool:
-    t = title or ""
-    b = body or ""
-    for p in patterns:
-        if p.search(t) or p.search(b):
-            return True
-    return False
-
-
 def purge_old_posts() -> None:
     """Remove posts older than ``DATA_RETENTION_DAYS`` from the database."""
     cutoff = datetime.now(timezone.utc) - timedelta(days=DATA_RETENTION_DAYS)


### PR DESCRIPTION
## Summary
- remove obsolete `_post_matches_ticker` helper from `reddit_scraper`
- rely on regex-based `str.contains` logic for ticker detection

## Testing
- `pytest -q` *(fails: SyntaxError in wallenstein/models.py)*

------
https://chatgpt.com/codex/tasks/task_e_68af5cde131083259a67b3075d49e8a1