### PR TITLE
Invoke config validation on startup

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,13 +8,15 @@ import duckdb
 import pandas as pd
 from dotenv import find_dotenv, load_dotenv
 
-from wallenstein.config import settings
-
 # --- .env laden ---
 env_loaded = load_dotenv(find_dotenv(usecwd=True), override=True)
 if not env_loaded:
     alt_path = Path(__file__).with_name(".env")
     load_dotenv(dotenv_path=alt_path, override=True)
+
+from wallenstein.config import settings, validate_config
+
+validate_config()
 
 # --- Logging ---
 LOG_LEVEL = settings.LOG_LEVEL.upper()

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -4,10 +4,12 @@ from telegram import Update
 from telegram.ext import ApplicationBuilder, ContextTypes, MessageHandler, filters
 
 from main import run_pipeline
-from wallenstein import config
+from wallenstein.config import settings, validate_config
 from wallenstein.overview import generate_overview
 
 log = logging.getLogger(__name__)
+
+validate_config()
 
 
 async def handle_ticker(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -35,7 +37,7 @@ async def handle_ticker(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
 
 def main() -> None:
     """Start the Telegram bot and listen for ticker commands."""
-    app = ApplicationBuilder().token(config.TELEGRAM_BOT_TOKEN).build()
+    app = ApplicationBuilder().token(settings.TELEGRAM_BOT_TOKEN).build()
     app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_ticker))
     app.run_polling()
 

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -16,9 +16,15 @@ sys.modules.setdefault(
 )
 
 # Ensure required environment variables exist
-os.environ.setdefault('CLIENT_ID', 'x')
-os.environ.setdefault('CLIENT_SECRET', 'x')
+os.environ.setdefault('REDDIT_CLIENT_ID', 'x')
+os.environ.setdefault('REDDIT_CLIENT_SECRET', 'x')
+os.environ.setdefault('REDDIT_USER_AGENT', 'x')
 os.environ.setdefault('TELEGRAM_BOT_TOKEN', 'x')
+os.environ.setdefault('TELEGRAM_CHAT_ID', 'x')
+
+import importlib
+import wallenstein.config as config_module
+importlib.reload(config_module)
 
 from telegram_bot import handle_ticker
 

--- a/wallenstein/config.py
+++ b/wallenstein/config.py
@@ -39,6 +39,17 @@ class Settings:
 settings = Settings()
 
 
-def validate_config():
-    if not settings.WALLENSTEIN_DB_PATH:
-        raise ValueError("DB path required")
+def validate_config() -> None:
+    required = {
+        "WALLENSTEIN_DB_PATH": settings.WALLENSTEIN_DB_PATH,
+        "TELEGRAM_BOT_TOKEN": settings.TELEGRAM_BOT_TOKEN,
+        "TELEGRAM_CHAT_ID": settings.TELEGRAM_CHAT_ID,
+        "REDDIT_CLIENT_ID": settings.REDDIT_CLIENT_ID,
+        "REDDIT_CLIENT_SECRET": settings.REDDIT_CLIENT_SECRET,
+        "REDDIT_USER_AGENT": settings.REDDIT_USER_AGENT,
+    }
+
+    missing = [name for name, value in required.items() if not value]
+    if missing:
+        missing_str = ", ".join(missing)
+        raise ValueError(f"Missing required environment variables: {missing_str}")


### PR DESCRIPTION
## Summary
- expand configuration validation to cover essential environment variables
- call `validate_config` during application and Telegram bot startup
- reload configuration in tests to accommodate stricter validation

## Testing
- `pre-commit run --files wallenstein/config.py main.py telegram_bot.py tests/test_telegram_bot.py`
- `pytest` *(fails: SyntaxError in wallenstein/models.py)*

------
https://chatgpt.com/codex/tasks/task_e_68af5cdea66883259886c40af4151b7b