### PR TITLE
Handle failures in wallenstein workflow

### DIFF
--- a/.github/workflows/wallenstein.yml
+++ b/.github/workflows/wallenstein.yml
@@ -18,9 +18,11 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
       - name: Run pipeline
+        id: run
         run: python main.py
+        continue-on-error: true
       - name: Telegram alert
-        if: failure()
+        if: steps.run.outcome == 'failure' && secrets.TELEGRAM_BOT_TOKEN && secrets.TELEGRAM_CHAT_ID
         run: |
           curl -s -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
             -d chat_id="${{ secrets.TELEGRAM_CHAT_ID }}" \


### PR DESCRIPTION
## Summary
- Prevent CI failure when pipeline step errors
- Notify via Telegram only on pipeline failures and when secrets are available

## Testing
- `pre-commit run --files .github/workflows/wallenstein.yml`
- `pytest` *(fails: tests/test_models.py::test_train_per_stock_smote, tests/test_models.py::test_train_per_stock_undersample)*

------
https://chatgpt.com/codex/tasks/task_e_68af70a5005883259d7e3554b6619869