### PR TITLE
Re-enable workflow with Reddit-prefixed secrets

### DIFF
--- a/.github/workflows/run_script.yml.disabled
+++ b/.github/workflows/run_script.yml.disabled
@@ -25,13 +25,10 @@ jobs:
       TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
       TELEGRAM_CHAT_ID:   ${{ secrets.TELEGRAM_CHAT_ID }}
 
-      # Reddit – mappe Secrets auf beide Namensräume
-      CLIENT_ID:            ${{ secrets.CLIENT_ID }}
-      CLIENT_SECRET:        ${{ secrets.CLIENT_SECRET }}
-      USER_AGENT:           ${{ secrets.USER_AGENT }}
-      REDDIT_CLIENT_ID:     ${{ secrets.CLIENT_ID }}
-      REDDIT_CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
-      REDDIT_USER_AGENT:    ${{ secrets.USER_AGENT }}
+      # Reddit
+      REDDIT_CLIENT_ID:     ${{ secrets.REDDIT_CLIENT_ID }}
+      REDDIT_CLIENT_SECRET: ${{ secrets.REDDIT_CLIENT_SECRET }}
+      REDDIT_USER_AGENT:    ${{ secrets.REDDIT_USER_AGENT }}
 
     steps:
       - name: Checkout
@@ -79,7 +76,7 @@ jobs:
       # --- DEBUG 2: ENV Sanity (ohne Werte zu leaken)
       - name: Sanity check env (masked)
         run: |
-          for v in CLIENT_ID CLIENT_SECRET USER_AGENT REDDIT_USER_AGENT TELEGRAM_BOT_TOKEN TELEGRAM_CHAT_ID; do
+          for v in REDDIT_CLIENT_ID REDDIT_CLIENT_SECRET REDDIT_USER_AGENT TELEGRAM_BOT_TOKEN TELEGRAM_CHAT_ID; do
             printf "%-20s %s\n" "$v:" "$([ -n "${!v}" ] && echo set || echo MISSING)"
           done
 

--- a/.github/workflows/wallenstein.yml
+++ b/.github/workflows/wallenstein.yml
@@ -6,17 +6,46 @@ on:
     - cron: '30 14-21 * * 1-5'
   workflow_dispatch:
 
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONUNBUFFERED: "1"
+  TZ: "Europe/Berlin"
+  WALLENSTEIN_DB_PATH: data/wallenstein.duckdb
+  WALLENSTEIN_YF_SLEEP: "0.6"
+
 jobs:
   run:
     runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+      TELEGRAM_CHAT_ID:   ${{ secrets.TELEGRAM_CHAT_ID }}
+      REDDIT_CLIENT_ID:     ${{ secrets.REDDIT_CLIENT_ID }}
+      REDDIT_CLIENT_SECRET: ${{ secrets.REDDIT_CLIENT_SECRET }}
+      REDDIT_USER_AGENT:    ${{ secrets.REDDIT_USER_AGENT }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: 'pip'
+          cache-dependency-path: |
+            requirements.txt
+            **/requirements.txt
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Prepare folders
+        run: mkdir -p data stockOverview
+      - name: Neutralize local .env on CI
+        run: |
+          if [ -f .env ]; then
+            echo "Found .env -> removing to avoid overriding secrets"
+            rm .env
+          else
+            echo "No .env present."
+          fi
       - name: Run pipeline
         run: python main.py
       - name: Telegram alert


### PR DESCRIPTION
## Summary
- re-enable `wallenstein` GitHub Actions workflow
- use `REDDIT_CLIENT_ID`, `REDDIT_CLIENT_SECRET`, and `REDDIT_USER_AGENT` secrets for Reddit configuration
- update debug `run_script` workflow to check the prefixed Reddit variables

## Testing
- `pre-commit run --files .github/workflows/wallenstein.yml .github/workflows/run_script.yml.disabled`
- `pytest` *(fails: tests/test_models.py::test_train_per_stock_smote, tests/test_models.py::test_train_per_stock_undersample)*

------
https://chatgpt.com/codex/tasks/task_e_68af8635d8ec8325b6749fc908cf7f91