### PR TITLE
Add CLI ticker override and alert notifications

### DIFF
--- a/alerts_api.py
+++ b/alerts_api.py
@@ -1,0 +1,69 @@
+"""Simple in-memory alert checking helper.
+
+The real project this kata is derived from exposes an external API for
+price alerts.  For the purposes of the exercises we implement a very
+small subset locally so that the main pipeline can interact with it
+without depending on any network resources.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict, List
+import logging
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class Alert:
+    id: int
+    ticker: str
+    threshold: float
+    direction: str = "above"  # either "above" or "below"
+
+
+_ALERTS: List[Alert] = []
+
+
+def register_alert(alert: Alert) -> None:
+    """Register a new alert in the in-memory store."""
+
+    _ALERTS.append(alert)
+
+
+def active_alerts(prices: Dict[str, float], notifier: Callable[[str], bool] | None = None) -> None:
+    """Check active alerts against the provided ``prices``.
+
+    If an alert is triggered the ``notifier`` callable is invoked with a
+    human readable message and the alert is removed ("deactivated").
+    """
+
+    remaining: List[Alert] = []
+    for alert in _ALERTS:
+        price = prices.get(alert.ticker)
+        if price is None:
+            remaining.append(alert)
+            continue
+        triggered = (
+            price >= alert.threshold if alert.direction == "above" else price <= alert.threshold
+        )
+        if triggered:
+            message = (
+                f"{alert.ticker} price {price:.2f} {'≥' if alert.direction == 'above' else '≤'} "
+                f"{alert.threshold:.2f}"
+            )
+            if notifier:
+                try:
+                    notifier(message)
+                except Exception as exc:  # pragma: no cover - notifier failures
+                    log.warning("Alert notification failed: %s", exc)
+        else:
+            remaining.append(alert)
+
+    # deactivate triggered alerts
+    _ALERTS[:] = remaining
+
+
+__all__ = ["Alert", "active_alerts", "register_alert"]
+

--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+import argparse
 import logging
 import os
 import time
@@ -46,12 +47,16 @@ except Exception as e:  # pragma: no cover
         return {t: [] for t in tickers}
 
 
+# Alerts API optional
+try:
+    import alerts_api
+except Exception as e:  # pragma: no cover
+    log.warning(f"alerts_api nicht verfügbar: {e}")
+    alerts_api = None
+
 # --- Pfade/Konfig ---
 DB_PATH = settings.WALLENSTEIN_DB_PATH
 os.makedirs(Path(DB_PATH).parent, exist_ok=True)  # stellt sicher, dass data/ existiert
-
-# Ticker (Standard inkl. TSLA)
-TICKERS = [t.strip().upper() for t in settings.WALLENSTEIN_TICKERS.split(",") if t.strip()]
 
 # Telegram (zur Rückwärtskompatibilität beibehalten)
 TELEGRAM_BOT_TOKEN = (settings.TELEGRAM_BOT_TOKEN or "").strip()
@@ -65,13 +70,33 @@ from wallenstein.sentiment import analyze_sentiment_batch
 from wallenstein.stock_data import update_fx_rates, update_prices
 
 
+def resolve_tickers(override: str | None = None) -> list[str]:
+    """Ermittle die zu verarbeitenden Ticker."""
+    if override:
+        tickers = [t.strip().upper() for t in override.split(",") if t.strip()]
+    else:
+        try:
+            from wallenstein.watchlist import all_unique_symbols
+
+            tickers = [s.strip().upper() for s in all_unique_symbols()]
+        except Exception as exc:  # pragma: no cover - unexpected failures
+            log.warning(f"Watchlist-Abfrage fehlgeschlagen: {exc}")
+            tickers = []
+    if not tickers:
+        log.warning("Keine Ticker gefunden")
+    return tickers
+
+
 # ---------- Main ----------
 def run_pipeline(tickers: list[str] | None = None) -> int:
     t0 = time.time()
     log.info("🚀 Start Wallenstein: Pipeline-Run")
 
     if tickers is None:
-        tickers = TICKERS
+        tickers = resolve_tickers()
+    if not tickers:
+        log.warning("Keine Ticker zur Verarbeitung – Pipeline abgebrochen")
+        return 1
 
     reddit_posts = {t: [] for t in tickers}
     added = 0
@@ -112,6 +137,11 @@ def run_pipeline(tickers: list[str] | None = None) -> int:
     ensure_prices_view(DB_PATH, view_name="stocks", table_name="prices")
     prices_usd = get_latest_prices(DB_PATH, tickers, use_eur=False)
     log.info(f"USD: {prices_usd}")
+    if alerts_api:
+        try:
+            alerts_api.active_alerts(prices_usd, notify_telegram)
+        except Exception as e:  # pragma: no cover - alert backend failures
+            log.warning(f"Alertprüfung fehlgeschlagen: {e}")
 
     # Sentiment je Ticker aus Reddit-Posts
     sentiments: dict[str, float] = {}
@@ -198,6 +228,15 @@ def run_pipeline(tickers: list[str] | None = None) -> int:
     log.info(f"🏁 Fertig in {time.time() - t0:.1f}s")
     return 0
 
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run Wallenstein pipeline")
+    parser.add_argument("--tickers", help="Kommagetrennte Liste von Ticker-Symbolen")
+    args = parser.parse_args()
+    tickers = resolve_tickers(args.tickers)
+    if not tickers:
+        return
+    run_pipeline(tickers)
+
 
 if __name__ == "__main__":
-    run_pipeline()
+    main()

--- a/wallenstein/models.py
+++ b/wallenstein/models.py
@@ -237,6 +237,12 @@ def train_per_stock(
         train_size = max(int(len(df) * 0.8), 1)
         df_train = df.iloc[:train_size]
         df_test = df.iloc[train_size:]
+        y_train = df_train["y"]
+        if balance_method in {"smote", "undersample"} and not df_test.empty:
+            while y_train.value_counts().min() < 2 and len(df_train) < len(df):
+                df_train = df.iloc[: len(df_train) + 1]
+                y_train = df_train["y"]
+            df_test = df.iloc[len(df_train):]
         X_train = df_train[features]
         y_train = df_train["y"]
         if y_train.nunique() < 2:

--- a/wallenstein/watchlist.py
+++ b/wallenstein/watchlist.py
@@ -1,0 +1,30 @@
+"""Utility helpers around the user's watchlist.
+
+This is a tiny shim for the purposes of this kata.  In a real
+application the watchlist would likely be stored in a database or be
+configurable through an API.  For now we simply read the comma separated
+list from the configuration and return the unique, normalised symbols.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from .config import settings
+
+
+def all_unique_symbols() -> List[str]:
+    """Return a list of unique ticker symbols from the configuration.
+
+    ``settings.WALLENSTEIN_TICKERS`` contains a comma separated list of
+    tickers.  This helper normalises the values and returns them as a
+    list.  It acts as a lightweight replacement for a potential database
+    backed watchlist module.
+    """
+
+    raw = settings.WALLENSTEIN_TICKERS
+    return [t.strip().upper() for t in raw.split(",") if t.strip()]
+
+
+__all__ = ["all_unique_symbols"]
+


### PR DESCRIPTION
## Summary
- allow passing a comma-separated list of tickers via `--tickers` and resolve symbols through a new `resolve_tickers` helper and watchlist module
- call `alerts_api.active_alerts` after price updates to send one-shot Telegram notifications
- expose a simple in-memory alerts API and watchlist helper
- ensure model training for SMOTE/undersample contains at least two class samples

## Testing
- `pytest -q` *(fails: test_train_per_stock_smote, test_train_per_stock_undersample)*

------
https://chatgpt.com/codex/tasks/task_e_68b218f7332483259517e87f04fa7e15