### PR TITLE
Add watchlist management utilities

### DIFF
--- a/tests/test_watchlist.py
+++ b/tests/test_watchlist.py
@@ -1,0 +1,31 @@
+import duckdb
+
+from wallenstein.watchlist import (
+    add_symbols,
+    remove_symbols,
+    list_symbols,
+    all_unique_symbols,
+)
+
+
+def test_add_list_remove_watchlist():
+    con = duckdb.connect(":memory:")
+
+    add_symbols(con, "chat1", ["aapl", "msft"], note="tech")
+    assert list_symbols(con, "chat1") == [("AAPL", "tech"), ("MSFT", "tech")]
+
+    add_symbols(con, "chat2", ["msft", "goog"], note=None)
+    assert set(all_unique_symbols(con)) == {"AAPL", "GOOG", "MSFT"}
+
+    removed = remove_symbols(con, "chat1", ["aapl"])
+    assert removed == 1
+    assert list_symbols(con, "chat1") == [("MSFT", "tech")]
+    assert set(all_unique_symbols(con)) == {"GOOG", "MSFT"}
+
+    # updating note should replace existing entry
+    add_symbols(con, "chat1", ["msft"], note="updated")
+    assert list_symbols(con, "chat1") == [("MSFT", "updated")]
+
+    # removing a non-existent symbol should affect nothing
+    removed = remove_symbols(con, "chat1", ["tsla"])
+    assert removed == 0

--- a/wallenstein/watchlist.py
+++ b/wallenstein/watchlist.py
@@ -1,0 +1,78 @@
+from typing import Iterable, List, Tuple
+
+import duckdb
+
+
+def _ensure_table(con: duckdb.DuckDBPyConnection) -> None:
+    con.execute(
+        """
+        CREATE TABLE IF NOT EXISTS watchlist (
+            chat_id VARCHAR,
+            symbol VARCHAR,
+            note VARCHAR,
+            UNIQUE(chat_id, symbol)
+        )
+        """
+    )
+
+
+def add_symbols(
+    con: duckdb.DuckDBPyConnection,
+    chat_id: str,
+    symbols: Iterable[str],
+    note: str | None = None,
+) -> List[str]:
+    """Add ``symbols`` for ``chat_id``.
+
+    Symbols are uppercased before insertion. Returns the list of inserted symbols
+    (uppercased).
+    """
+    _ensure_table(con)
+    symbols_upper = [s.upper() for s in symbols]
+    data = [(chat_id, sym, note) for sym in symbols_upper]
+    if data:
+        con.executemany(
+            "INSERT OR REPLACE INTO watchlist (chat_id, symbol, note) VALUES (?, ?, ?)",
+            data,
+        )
+    return symbols_upper
+
+
+def remove_symbols(
+    con: duckdb.DuckDBPyConnection,
+    chat_id: str,
+    symbols: Iterable[str],
+) -> int:
+    """Remove ``symbols`` for ``chat_id`` and return number of removed rows."""
+    _ensure_table(con)
+    symbols_upper = [s.upper() for s in symbols]
+    if not symbols_upper:
+        return 0
+    placeholders = ", ".join(["?"] * len(symbols_upper))
+    params = [chat_id, *symbols_upper]
+    count = con.execute(
+        f"SELECT COUNT(*) FROM watchlist WHERE chat_id = ? AND symbol IN ({placeholders})",
+        params,
+    ).fetchone()[0]
+    con.execute(
+        f"DELETE FROM watchlist WHERE chat_id = ? AND symbol IN ({placeholders})",
+        params,
+    )
+    return int(count)
+
+
+def list_symbols(con: duckdb.DuckDBPyConnection, chat_id: str) -> List[Tuple[str, str | None]]:
+    """List all symbols with optional note for ``chat_id``."""
+    _ensure_table(con)
+    rows = con.execute(
+        "SELECT symbol, note FROM watchlist WHERE chat_id = ? ORDER BY symbol",
+        [chat_id],
+    ).fetchall()
+    return [(row[0], row[1]) for row in rows]
+
+
+def all_unique_symbols(con: duckdb.DuckDBPyConnection) -> List[str]:
+    """Return all unique symbols across all chat ids."""
+    _ensure_table(con)
+    rows = con.execute("SELECT DISTINCT symbol FROM watchlist ORDER BY symbol").fetchall()
+    return [row[0] for row in rows]


### PR DESCRIPTION
## Summary
- add DuckDB-powered watchlist helpers for adding, removing, listing and aggregating symbols
- ensure symbols are uppercased and stored with chat id and optional note
- cover watchlist logic with unit tests

## Testing
- `ruff check wallenstein/watchlist.py`
- `pytest -q` *(fails: test_train_per_stock_smote, test_train_per_stock_undersample)*
- `PYTHONPATH=. pytest tests/test_watchlist.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b218f8edb4832595ab8234835eed33