### PR TITLE
Initialize DuckDB schema and invoke at startup

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ if not env_loaded:
     load_dotenv(dotenv_path=alt_path, override=True)
 
 from wallenstein.config import settings, validate_config
+from wallenstein.db import init_schema
 
 validate_config()
 
@@ -49,6 +50,7 @@ except Exception as e:  # pragma: no cover
 # --- Pfade/Konfig ---
 DB_PATH = settings.WALLENSTEIN_DB_PATH
 os.makedirs(Path(DB_PATH).parent, exist_ok=True)  # stellt sicher, dass data/ existiert
+init_schema(DB_PATH)
 
 # Ticker (Standard inkl. TSLA)
 TICKERS = [t.strip().upper() for t in settings.WALLENSTEIN_TICKERS.split(",") if t.strip()]

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -5,11 +5,13 @@ from telegram.ext import ApplicationBuilder, ContextTypes, MessageHandler, filte
 
 from main import run_pipeline
 from wallenstein.config import settings, validate_config
+from wallenstein.db import init_schema
 from wallenstein.overview import generate_overview
 
 log = logging.getLogger(__name__)
 
 validate_config()
+init_schema()
 
 
 async def handle_ticker(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/wallenstein/db.py
+++ b/wallenstein/db.py
@@ -1,0 +1,42 @@
+"""Database helpers for Wallenstein.
+
+This module provides a small wrapper around DuckDB that ensures the
+application's schema is initialised.  The schema itself lives in
+``schema.sql`` so it can easily be inspected or adapted without touching
+Python code.
+"""
+
+from __future__ import annotations
+
+from importlib import resources
+from pathlib import Path
+
+import duckdb
+
+from .config import settings
+
+
+def get_connection(db_path: str | None = None) -> duckdb.DuckDBPyConnection:
+    """Return a DuckDB connection.
+
+    The directory of ``db_path`` is created automatically.  If ``db_path`` is
+    ``None`` the path from the application settings is used.
+    """
+    path = Path(db_path or settings.WALLENSTEIN_DB_PATH)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return duckdb.connect(path)
+
+
+def _execute_script(con: duckdb.DuckDBPyConnection, script: str) -> None:
+    """Execute a multi-statement SQL script."""
+    for statement in script.split(";"):
+        stmt = statement.strip()
+        if stmt:
+            con.execute(stmt)
+
+
+def init_schema(db_path: str | None = None) -> None:
+    """Create required tables if they do not yet exist."""
+    with get_connection(db_path) as con:
+        schema_sql = resources.files(__package__).joinpath("schema.sql").read_text()
+        _execute_script(con, schema_sql)

--- a/wallenstein/schema.sql
+++ b/wallenstein/schema.sql
@@ -1,0 +1,18 @@
+-- SQL schema for Wallenstein watchlists and alerts
+
+CREATE TABLE IF NOT EXISTS watchlists (
+    chat_id TEXT NOT NULL,
+    ticker TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (chat_id, ticker)
+);
+
+CREATE TABLE IF NOT EXISTS alerts (
+    chat_id TEXT NOT NULL,
+    ticker TEXT NOT NULL,
+    target_price DOUBLE NOT NULL,
+    direction TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    triggered_at TIMESTAMP,
+    PRIMARY KEY (chat_id, ticker, target_price, direction)
+);


### PR DESCRIPTION
## Summary
- add SQL schema for watchlists and alerts
- provide DuckDB helpers to initialise schema
- initialise schema on startup in main application and Telegram bot

## Testing
- `pre-commit run --files main.py telegram_bot.py wallenstein/db.py wallenstein/schema.sql`
- `pytest` *(fails: tests/test_models.py::test_train_per_stock_smote, tests/test_models.py::test_train_per_stock_undersample)*

------
https://chatgpt.com/codex/tasks/task_e_68b218f7e8bc8325aa73e0f031b337e7