### PR TITLE
Add get_last_close helper and tests

### DIFF
--- a/wallenstein/stock_data.py
+++ b/wallenstein/stock_data.py
@@ -889,3 +889,27 @@ def update_fx_rates(db_path: str) -> int:
             con.close()
         except Exception:
             pass
+
+
+def get_last_close(con: duckdb.DuckDBPyConnection, symbol: str) -> float:
+    """Return the most recent close price for ``symbol``.
+
+    If no close is available for the given ``symbol`` or the query fails,
+    ``float('nan')`` is returned.
+    """
+    try:
+        row = con.execute(
+            """
+            SELECT close
+            FROM prices
+            WHERE ticker = ?
+            ORDER BY date DESC
+            LIMIT 1
+            """,
+            [symbol],
+        ).fetchone()
+        if row and row[0] is not None:
+            return float(row[0])
+        return float("nan")
+    except Exception:
+        return float("nan")


### PR DESCRIPTION
## Summary
- add `get_last_close` to fetch most recent close for a ticker, returning NaN if none
- cover new utility with tests for existing and missing data

## Testing
- `ruff check wallenstein/stock_data.py tests/test_stock_data.py`
- `pytest -q` *(fails: tests/test_models.py::test_train_per_stock_smote, tests/test_models.py::test_train_per_stock_undersample)*
- `PYTHONPATH=. pytest tests/test_stock_data.py::test_get_last_close_returns_value tests/test_stock_data.py::test_get_last_close_returns_nan_when_missing -q`


------
https://chatgpt.com/codex/tasks/task_e_68b218fb02d48325b61d455cc6fc56bc