### PR TITLE
Add alert management utilities and tests

### DIFF
--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -1,0 +1,47 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from wallenstein import alerts
+
+
+def setup_function():
+    alerts._ALERTS.clear()
+    alerts._NEXT_ID = 1
+
+
+def test_add_list_delete_alert():
+    a1 = alerts.add_alert("aapl", "<=", 100)
+    assert a1.symbol == "AAPL"
+    assert a1.operator == "<="
+    assert len(alerts.list_alerts()) == 1
+
+    assert alerts.delete_alert(a1.id) is True
+    assert alerts.list_alerts() == []
+
+
+def test_invalid_operator():
+    with pytest.raises(ValueError):
+        alerts.add_alert("aapl", "==", 100)
+
+
+def test_activation_deactivation_flow():
+    a1 = alerts.add_alert("msft", ">=", 200)
+    a2 = alerts.add_alert("goog", "<", 150)
+
+    assert len(alerts.active_alerts()) == 2
+
+    assert alerts.deactivate(a1.id) is True
+
+    actives = alerts.active_alerts()
+    assert len(actives) == 1
+    assert actives[0].id == a2.id
+
+    all_alerts = alerts.list_alerts()
+    assert len(all_alerts) == 2
+    assert not [a for a in all_alerts if a.id == a1.id][0].active

--- a/wallenstein/alerts.py
+++ b/wallenstein/alerts.py
@@ -1,0 +1,87 @@
+"""In-memory alert management utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+_ALLOWED_OPERATORS = {"<", ">", "<=", ">="}
+
+
+@dataclass
+class Alert:
+    """Simple alert representation."""
+
+    id: int
+    symbol: str
+    operator: str
+    price: float
+    active: bool = True
+
+
+_ALERTS: List[Alert] = []
+_NEXT_ID = 1
+
+
+def _normalize_symbol(symbol: str) -> str:
+    return symbol.upper()
+
+
+def _validate_operator(op: str) -> str:
+    if op not in _ALLOWED_OPERATORS:
+        raise ValueError(f"Invalid operator: {op}")
+    return op
+
+
+def add_alert(symbol: str, operator: str, price: float) -> Alert:
+    """Add a new alert and return it.
+
+    Operator must be one of ``<``, ``>``, ``<=`` or ``>=``.
+    The symbol is normalised to uppercase.
+    """
+
+    global _NEXT_ID
+    symbol = _normalize_symbol(symbol)
+    operator = _validate_operator(operator)
+    alert = Alert(id=_NEXT_ID, symbol=symbol, operator=operator, price=float(price))
+    _ALERTS.append(alert)
+    _NEXT_ID += 1
+    return alert
+
+
+def list_alerts(symbol: Optional[str] = None) -> List[Alert]:
+    """Return all alerts, optionally filtered by symbol."""
+
+    if symbol is not None:
+        symbol = _normalize_symbol(symbol)
+        return [a for a in _ALERTS if a.symbol == symbol]
+    return list(_ALERTS)
+
+
+def delete_alert(alert_id: int) -> bool:
+    """Delete alert by ID. Returns ``True`` if removed."""
+
+    for i, alert in enumerate(_ALERTS):
+        if alert.id == alert_id:
+            del _ALERTS[i]
+            return True
+    return False
+
+
+def active_alerts(symbol: Optional[str] = None) -> List[Alert]:
+    """Return all active alerts, optionally filtered by symbol."""
+
+    if symbol is not None:
+        symbol = _normalize_symbol(symbol)
+        return [a for a in _ALERTS if a.active and a.symbol == symbol]
+    return [a for a in _ALERTS if a.active]
+
+
+def deactivate(alert_id: int) -> bool:
+    """Deactivate an alert by ID. Returns ``True`` if found."""
+
+    for alert in _ALERTS:
+        if alert.id == alert_id:
+            alert.active = False
+            return True
+    return False


### PR DESCRIPTION
## Summary
- add in-memory alert management with CRUD operations and activation control
- validate alert operators and normalise symbols to uppercase
- test alert add/list/delete and activation/deactivation flows

## Testing
- `pytest`
- `pytest tests/test_alerts.py`


------
https://chatgpt.com/codex/tasks/task_e_68b218f980b483259d5298fa15a622a7