### PR TITLE
Add alert reactivation support and tests

### DIFF
--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -1,0 +1,33 @@
+import duckdb
+
+from wallenstein import alerts
+
+
+class DummyConn:
+    def __init__(self):
+        self._con = duckdb.connect(":memory:")
+
+    def execute(self, *args, **kwargs):
+        return self._con.execute(*args, **kwargs)
+
+    def close(self) -> None:  # pragma: no cover - no-op for tests
+        pass
+
+
+def _setup_db(monkeypatch):
+    con = DummyConn()
+    monkeypatch.setattr(alerts.duckdb, "connect", lambda _: con)
+    return con
+
+
+def test_reactivate_alert(monkeypatch):
+    _setup_db(monkeypatch)
+    first = alerts.add_alert("NVDA", ">", 100)
+    second = alerts.add_alert("AMZN", "<", 50)
+    assert {a.id for a in alerts.active_alerts()} == {first, second}
+
+    alerts.deactivate(first)
+    assert {a.id for a in alerts.active_alerts()} == {second}
+
+    assert alerts.activate(first) is True
+    assert {a.id for a in alerts.active_alerts()} == {first, second}

--- a/wallenstein/alerts.py
+++ b/wallenstein/alerts.py
@@ -56,6 +56,12 @@ def list_alerts(db_path: str | None = None) -> list[Alert]:
         con.close()
 
 
+def active_alerts(db_path: str | None = None) -> list[Alert]:
+    """Return only alerts marked as active."""
+
+    return [a for a in list_alerts(db_path) if a.active]
+
+
 def delete_alert(alert_id: int, db_path: str | None = None) -> None:
     db_path = db_path or settings.WALLENSTEIN_DB_PATH
     con = duckdb.connect(db_path)
@@ -66,19 +72,33 @@ def delete_alert(alert_id: int, db_path: str | None = None) -> None:
         con.close()
 
 
-def _set_active(alert_id: int, active: bool, db_path: str | None = None) -> None:
+def _set_active(alert_id: int, active: bool, db_path: str | None = None) -> bool:
     db_path = db_path or settings.WALLENSTEIN_DB_PATH
     con = duckdb.connect(db_path)
     try:
         _ensure_table(con)
         con.execute("UPDATE alerts SET active = ? WHERE id = ?", [active, alert_id])
+        row = con.execute("SELECT COUNT(*) FROM alerts WHERE id = ?", [alert_id]).fetchone()
+        return bool(row and row[0])
     finally:
         con.close()
 
 
-def activate_alert(alert_id: int, db_path: str | None = None) -> None:
-    _set_active(alert_id, True, db_path)
+def activate(alert_id: int, db_path: str | None = None) -> bool:
+    """Activate the alert with the given ``alert_id``.
+
+    Returns ``True`` if the alert exists and was activated.
+    """
+
+    return _set_active(alert_id, True, db_path)
 
 
-def deactivate_alert(alert_id: int, db_path: str | None = None) -> None:
-    _set_active(alert_id, False, db_path)
+def deactivate(alert_id: int, db_path: str | None = None) -> bool:
+    """Deactivate the alert with the given ``alert_id``."""
+
+    return _set_active(alert_id, False, db_path)
+
+
+# Backwards compatibility
+activate_alert = activate
+deactivate_alert = deactivate


### PR DESCRIPTION
## Summary
- Add `active_alerts` helper and `activate`/`deactivate` functions returning success flags
- Include backwards-compatible aliases and database update handling
- Test that deactivated alerts can be reactivated and appear again in active list

## Testing
- `ruff check wallenstein/alerts.py tests/test_alerts.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'wallenstein'; SyntaxError in wallenstein/watchlist.py)*
- `PYTHONPATH=$PWD pytest tests/test_alerts.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b222da8fd88325bfe44f3977dc69e6