### PR TITLE
Persist alerts in database and adjust tests

### DIFF
--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -1,50 +1,8 @@
-
-import sys
-from pathlib import Path
-
-
-
 import duckdb
-
+import pytest
 
 from wallenstein import alerts
 
-
-def setup_function():
-    alerts._ALERTS.clear()
-    alerts._NEXT_ID = 1
-
-
-def test_add_list_delete_alert():
-    a1 = alerts.add_alert("aapl", "<=", 100)
-    assert a1.symbol == "AAPL"
-    assert a1.operator == "<="
-    assert len(alerts.list_alerts()) == 1
-
-    assert alerts.delete_alert(a1.id) is True
-    assert alerts.list_alerts() == []
-
-
-def test_invalid_operator():
-    with pytest.raises(ValueError):
-        alerts.add_alert("aapl", "==", 100)
-
-
-def test_activation_deactivation_flow():
-    a1 = alerts.add_alert("msft", ">=", 200)
-    a2 = alerts.add_alert("goog", "<", 150)
-
-    assert len(alerts.active_alerts()) == 2
-
-    assert alerts.deactivate(a1.id) is True
-
-    actives = alerts.active_alerts()
-    assert len(actives) == 1
-    assert actives[0].id == a2.id
-
-    all_alerts = alerts.list_alerts()
-    assert len(all_alerts) == 2
-    assert not [a for a in all_alerts if a.id == a1.id][0].active
 
 class DummyConn:
     def __init__(self):
@@ -63,6 +21,41 @@ def _setup_db(monkeypatch):
     return con
 
 
+def test_add_list_delete_alert(monkeypatch):
+    _setup_db(monkeypatch)
+    a1 = alerts.add_alert("aapl", "<=", 100)
+    assert a1.symbol == "AAPL"
+    assert a1.operator == "<="
+    assert len(alerts.list_alerts()) == 1
+
+    assert alerts.delete_alert(a1.id) is True
+    assert alerts.list_alerts() == []
+
+
+def test_invalid_operator(monkeypatch):
+    _setup_db(monkeypatch)
+    with pytest.raises(ValueError):
+        alerts.add_alert("aapl", "==", 100)
+
+
+def test_activation_deactivation_flow(monkeypatch):
+    _setup_db(monkeypatch)
+    a1 = alerts.add_alert("msft", ">=", 200)
+    a2 = alerts.add_alert("goog", "<", 150)
+
+    assert len(alerts.active_alerts()) == 2
+
+    assert alerts.deactivate(a1.id) is True
+
+    actives = alerts.active_alerts()
+    assert len(actives) == 1
+    assert actives[0].id == a2.id
+
+    all_alerts = alerts.list_alerts()
+    assert len(all_alerts) == 2
+    assert not [a for a in all_alerts if a.id == a1.id][0].active
+
+
 def test_reactivate_alert(monkeypatch):
     _setup_db(monkeypatch)
     first = alerts.add_alert("NVDA", ">", 100)
@@ -74,4 +67,3 @@ def test_reactivate_alert(monkeypatch):
 
     assert alerts.activate(first) is True
     assert {a.id for a in alerts.active_alerts()} == {first, second}
-

--- a/wallenstein/alerts.py
+++ b/wallenstein/alerts.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 from typing import List, Optional, Union
 
 import duckdb
 
-from .config import settings
+try:  # optional during some tests
+    from .config import settings  # type: ignore
+except Exception:  # pragma: no cover - config is optional
+    settings = None  # type: ignore
 
 _ALLOWED_OPERATORS = {"<", ">", "<=", ">="}
 
@@ -30,7 +31,7 @@ class Alert:
             return self.id == other
         return NotImplemented
 
-    # Backward-compatible aliases
+    # Backwards compatible aliases
     @property
     def symbol(self) -> str:  # pragma: no cover - simple alias
         return self.ticker
@@ -40,8 +41,7 @@ class Alert:
         return self.op
 
 
-_ALERTS: List[Alert] = []
-_NEXT_ID = 1
+# ---------- Helpers ----------
 
 
 def _normalize_ticker(ticker: str) -> str:
@@ -54,81 +54,12 @@ def _validate_op(op: str) -> str:
     return op
 
 
-def add_alert(ticker: str, op: str, price: float) -> Alert:
-    """Add a new alert and return the created object."""
-    global _NEXT_ID
-    ticker = _normalize_ticker(ticker)
-    op = _validate_op(op)
-    for i, existing in enumerate(_ALERTS):
-        if existing.ticker == ticker:
-            alert = Alert(id=existing.id, ticker=ticker, op=op, price=float(price))
-            _ALERTS[i] = alert
-            return alert
-    alert = Alert(id=_NEXT_ID, ticker=ticker, op=op, price=float(price))
-    _ALERTS.append(alert)
-    _NEXT_ID += 1
-    return alert
-
-
-def list_alerts(ticker: Optional[str] = None) -> List[Alert]:
-    if ticker is not None:
-        sym = _normalize_ticker(ticker)
-        return [a for a in _ALERTS if a.ticker == sym]
-    return list(_ALERTS)
-
-
-def delete_alert(alert_id: Union[int, Alert]) -> bool:
-    aid = alert_id.id if isinstance(alert_id, Alert) else int(alert_id)
-    for i, alert in enumerate(_ALERTS):
-        if alert.id == aid:
-            del _ALERTS[i]
-            return True
-    return False
-
-
-def active_alerts(ticker: Optional[str] = None) -> List[Alert]:
-    if ticker is not None:
-        sym = _normalize_ticker(ticker)
-        return [a for a in _ALERTS if a.active and a.ticker == sym]
-    return [a for a in _ALERTS if a.active]
-
-
-def deactivate(alert_id: Union[int, Alert]) -> bool:
-    aid = alert_id.id if isinstance(alert_id, Alert) else int(alert_id)
-    for i, alert in enumerate(_ALERTS):
-        if alert.id == aid:
-            _ALERTS[i] = Alert(
-                id=alert.id,
-                ticker=alert.ticker,
-                op=alert.op,
-                price=alert.price,
-                active=False,
-            )
-            return True
-    return False
-
-
-def activate(alert_id: Union[int, Alert]) -> bool:
-    aid = alert_id.id if isinstance(alert_id, Alert) else int(alert_id)
-    for i, alert in enumerate(_ALERTS):
-        if alert.id == aid:
-            _ALERTS[i] = Alert(
-                id=alert.id,
-                ticker=alert.ticker,
-                op=alert.op,
-                price=alert.price,
-                active=True,
-            )
-            return True
-    return False
-
-
-# Backwards compatible names
-deactivate_alert = deactivate
-activate_alert = activate
-
-
-# -- Optional DB helpers --
+def _get_db_path(db_path: Optional[str] = None) -> str:
+    if db_path:
+        return db_path
+    if settings is None or not getattr(settings, "WALLENSTEIN_DB_PATH", None):
+        return "data/wallenstein.duckdb"
+    return settings.WALLENSTEIN_DB_PATH
 
 
 def _ensure_table(con: duckdb.DuckDBPyConnection) -> None:
@@ -145,14 +76,139 @@ def _ensure_table(con: duckdb.DuckDBPyConnection) -> None:
     )
 
 
-def add_alert_db(ticker: str, op: str, price: float, db_path: str | None = None) -> int:
-    db_path = db_path or settings.WALLENSTEIN_DB_PATH
-    with duckdb.connect(db_path) as con:
-        _ensure_table(con)
-        cur = con.execute(
-            "INSERT INTO alerts (ticker, op, price, active) VALUES (?, ?, ?, TRUE)",
-            [ticker, op, price],
-        )
-        row = cur.fetchone()
-        return row[0] if row else 0
+# ---------- CRUD API ----------
 
+
+def add_alert(ticker: str, op: str, price: float, db_path: Optional[str] = None) -> Alert:
+    """Add a new alert or update existing one for ticker."""
+    ticker = _normalize_ticker(ticker)
+    op = _validate_op(op)
+    path = _get_db_path(db_path)
+    con = duckdb.connect(path)
+    try:
+        _ensure_table(con)
+        row = con.execute("SELECT id FROM alerts WHERE ticker = ?", [ticker]).fetchone()
+        if row:
+            alert_id = int(row[0])
+            con.execute(
+                "UPDATE alerts SET op = ?, price = ?, active = TRUE WHERE id = ?",
+                [op, float(price), alert_id],
+            )
+        else:
+            alert_id = con.execute(
+                "SELECT COALESCE(MAX(id), 0) + 1 FROM alerts"
+            ).fetchone()[0]
+            con.execute(
+                "INSERT INTO alerts (id, ticker, op, price, active) VALUES (?, ?, ?, ?, TRUE)",
+                [alert_id, ticker, op, float(price)],
+            )
+        data = con.execute(
+            "SELECT id, ticker, op, price, active FROM alerts WHERE id = ?", [alert_id]
+        ).fetchone()
+        return Alert(*data)
+    finally:
+        con.close()
+
+
+def list_alerts(ticker: Optional[str] = None, db_path: Optional[str] = None) -> List[Alert]:
+    path = _get_db_path(db_path)
+    con = duckdb.connect(path)
+    try:
+        _ensure_table(con)
+        if ticker is not None:
+            sym = _normalize_ticker(ticker)
+            rows = con.execute(
+                "SELECT id, ticker, op, price, active FROM alerts WHERE ticker = ? ORDER BY id",
+                [sym],
+            ).fetchall()
+        else:
+            rows = con.execute(
+                "SELECT id, ticker, op, price, active FROM alerts ORDER BY id"
+            ).fetchall()
+        return [Alert(*r) for r in rows]
+    finally:
+        con.close()
+
+
+def delete_alert(alert_id: Union[int, Alert], db_path: Optional[str] = None) -> bool:
+    aid = alert_id.id if isinstance(alert_id, Alert) else int(alert_id)
+    path = _get_db_path(db_path)
+    con = duckdb.connect(path)
+    try:
+        _ensure_table(con)
+        row = con.execute(
+            "DELETE FROM alerts WHERE id = ? RETURNING id",
+            [aid],
+        ).fetchone()
+        return row is not None
+    finally:
+        con.close()
+
+
+def active_alerts(ticker: Optional[str] = None, db_path: Optional[str] = None) -> List[Alert]:
+    path = _get_db_path(db_path)
+    con = duckdb.connect(path)
+    try:
+        _ensure_table(con)
+        if ticker is not None:
+            sym = _normalize_ticker(ticker)
+            rows = con.execute(
+                "SELECT id, ticker, op, price, active FROM alerts WHERE active AND ticker = ? ORDER BY id",
+                [sym],
+            ).fetchall()
+        else:
+            rows = con.execute(
+                "SELECT id, ticker, op, price, active FROM alerts WHERE active ORDER BY id"
+            ).fetchall()
+        return [Alert(*r) for r in rows]
+    finally:
+        con.close()
+
+
+def deactivate(alert_id: Union[int, Alert], db_path: Optional[str] = None) -> bool:
+    aid = alert_id.id if isinstance(alert_id, Alert) else int(alert_id)
+    path = _get_db_path(db_path)
+    con = duckdb.connect(path)
+    try:
+        _ensure_table(con)
+        row = con.execute(
+            "UPDATE alerts SET active = FALSE WHERE id = ? RETURNING id",
+            [aid],
+        ).fetchone()
+        return row is not None
+    finally:
+        con.close()
+
+
+def activate(alert_id: Union[int, Alert], db_path: Optional[str] = None) -> bool:
+    aid = alert_id.id if isinstance(alert_id, Alert) else int(alert_id)
+    path = _get_db_path(db_path)
+    con = duckdb.connect(path)
+    try:
+        _ensure_table(con)
+        row = con.execute(
+            "UPDATE alerts SET active = TRUE WHERE id = ? RETURNING id",
+            [aid],
+        ).fetchone()
+        return row is not None
+    finally:
+        con.close()
+
+
+# Backwards compatible names
+
+deactivate_alert = deactivate
+activate_alert = activate
+
+
+__all__ = [
+    "Alert",
+    "add_alert",
+    "list_alerts",
+    "delete_alert",
+    "active_alerts",
+    "deactivate",
+    "activate",
+    "deactivate_alert",
+    "activate_alert",
+]

--- a/wallenstein/db_schema.py
+++ b/wallenstein/db_schema.py
@@ -58,6 +58,13 @@ SCHEMAS = {
         "pair": "TEXT",
         "rate_usd_per_eur": "DOUBLE",
     },
+    "alerts": {
+        "id": "INTEGER",
+        "ticker": "TEXT",
+        "op": "TEXT",
+        "price": "DOUBLE",
+        "active": "BOOLEAN",
+    },
 }
 
 
@@ -68,6 +75,8 @@ def ensure_tables(con: duckdb.DuckDBPyConnection):
             coldefs += ", PRIMARY KEY (date, ticker)"
         if table == "reddit_trends":
             coldefs += ", PRIMARY KEY (date, ticker)"
+        if table == "alerts":
+            coldefs += ", PRIMARY KEY (id)"
         con.execute(f"CREATE TABLE IF NOT EXISTS {table} ({coldefs});")
         if table == "reddit_posts":
             info = con.execute("PRAGMA table_info('reddit_posts')").fetchall()

--- a/wallenstein/schema.sql
+++ b/wallenstein/schema.sql
@@ -8,11 +8,9 @@ CREATE TABLE IF NOT EXISTS watchlists (
 );
 
 CREATE TABLE IF NOT EXISTS alerts (
-    chat_id TEXT NOT NULL,
+    id INTEGER PRIMARY KEY,
     ticker TEXT NOT NULL,
-    target_price DOUBLE NOT NULL,
-    direction TEXT NOT NULL,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    triggered_at TIMESTAMP,
-    PRIMARY KEY (chat_id, ticker, target_price, direction)
+    op TEXT NOT NULL,
+    price DOUBLE NOT NULL,
+    active BOOLEAN DEFAULT TRUE
 );


### PR DESCRIPTION
## Summary
- add `alerts` table definition in schema and auto-ensure in db schema helper
- refactor alert CRUD to use DuckDB storage instead of in-memory list
- update alert tests to work with persistent DB-backed alerts

## Testing
- `ruff check wallenstein/alerts.py tests/test_alerts.py tests/test_watchlist_alerts.py wallenstein/db_schema.py`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b2d909db7c8325a4dcbd2bdc1892a0