### PR TITLE
Add Reddit enrichment pipeline and bot trend commands

### DIFF
--- a/wallenstein/reddit_enrich.py
+++ b/wallenstein/reddit_enrich.py
@@ -13,19 +13,10 @@ def enrich_reddit_posts(
     con: duckdb.DuckDBPyConnection,
     posts: dict[str, list[dict]],
     tickers: list[str],
-) -> None:
-    """Enrich raw Reddit posts and store them in ``reddit_enriched``.
+) -> int:
+    """Enrich and persist Reddit posts.
 
-    Parameters
-    ----------
-    con:
-        Active DuckDB connection.
-    posts:
-        Mapping of ticker to a list of post dictionaries as returned by
-        :func:`update_reddit_data`.
-    tickers:
-        List of tickers to consider. The mapping may contain more keys but only
-        these are processed.
+    Returns the number of inserted rows in ``reddit_enriched``.
     """
 
     rows: list[dict] = []
@@ -35,7 +26,6 @@ def enrich_reddit_posts(
             try:
                 post_id = int(raw_id, 36)
             except Exception:
-                # Skip comments or malformed IDs which cannot be converted
                 continue
             created = pd.to_datetime(post.get("created_utc"), utc=True)
             text = str(post.get("text", ""))
@@ -59,7 +49,7 @@ def enrich_reddit_posts(
             )
 
     if not rows:
-        return
+        return 0
 
     df = pd.DataFrame(rows)
     validate_df(df, "reddit_enriched")
@@ -78,10 +68,10 @@ def enrich_reddit_posts(
             mask = ~df.apply(lambda r: (int(r["id"]), r["ticker"]) in existing, axis=1)
             df = df.loc[mask]
     if df.empty:
-        return
+        return 0
 
     con.register("df_enriched", df)
-    con.execute(
+    inserted = con.execute(
         """
         INSERT INTO reddit_enriched (
             id, ticker, created_utc, text, upvotes,
@@ -92,14 +82,15 @@ def enrich_reddit_posts(
                sentiment_dict, sentiment_weighted, sentiment_ml,
                return_1d, return_3d, return_7d
         FROM df_enriched
-        """
-    )
+        """,
+    ).rowcount
+    return int(inserted)
 
 
-def compute_reddit_trends(con: duckdb.DuckDBPyConnection) -> None:
-    """Aggregate daily Reddit trends into ``reddit_trends`` table."""
+def compute_reddit_trends(con: duckdb.DuckDBPyConnection) -> int:
+    """Aggregate daily Reddit trends into ``reddit_trends``."""
 
-    con.execute(
+    result = con.execute(
         """
         INSERT OR REPLACE INTO reddit_trends
         SELECT date, ticker, mentions, avg_upvotes, hotness
@@ -113,33 +104,34 @@ def compute_reddit_trends(con: duckdb.DuckDBPyConnection) -> None:
             WHERE sentiment_dict IS NOT NULL
             GROUP BY date, ticker
         )
-        """
+        """,
     )
+    return int(result.rowcount)
 
 
 def compute_returns(
     con: duckdb.DuckDBPyConnection,
     horizon_days: tuple[int, ...] = (1, 3, 7),
-) -> None:
+) -> int:
     """Compute forward returns for posts in ``reddit_enriched``."""
 
     if not horizon_days:
-        return
+        return 0
 
     df_posts = con.execute(
         "SELECT id, ticker, created_utc FROM reddit_enriched"
     ).fetch_df()
     if df_posts.empty:
-        return
+        return 0
 
     df_prices = con.execute(
         "SELECT date, ticker, close FROM prices"
     ).fetch_df()
     if df_prices.empty:
-        return
-
+        return 0
     df_prices["date"] = pd.to_datetime(df_prices["date"])
 
+    updated = 0
     for row in df_posts.itertuples(index=False):
         prices_t = df_prices[df_prices["ticker"] == row.ticker].sort_values("date")
         base = prices_t[
@@ -149,13 +141,28 @@ def compute_returns(
             continue
         base_date = base["date"].iloc[0]
         base_close = base["close"].iloc[0]
+
+        ret_vals: list[float | None] = []
         for h in horizon_days:
             target = prices_t[prices_t["date"] >= base_date + pd.Timedelta(days=h)].head(1)
             if target.empty:
                 ret = None
             else:
                 ret = (target["close"].iloc[0] - base_close) / base_close
-            con.execute(
-                f"UPDATE reddit_enriched SET return_{h}d = ? WHERE id = ? AND ticker = ?",
-                [ret, row.id, row.ticker],
-            )
+            ret_vals.append(ret)
+
+        set_clause = ", ".join(f"return_{h}d = ?" for h in horizon_days)
+        con.execute(
+            f"UPDATE reddit_enriched SET {set_clause} WHERE id = ? AND ticker = ?",
+            ret_vals + [row.id, row.ticker],
+        )
+        updated += 1
+    return updated
+
+
+__all__ = [
+    "enrich_reddit_posts",
+    "compute_reddit_trends",
+    "compute_returns",
+]
+


### PR DESCRIPTION
## Summary
- enrich Reddit posts with weighted sentiment and compute returns & trends
- show weighted sentiment and Reddit trends in overview and bot commands
- extend bot with /trends and /sentiment commands

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b2df6f6dd08325bae5119d2df2b420