### PR TITLE
Refactor reddit enrichment to string IDs

### DIFF
--- a/main.py
+++ b/main.py
@@ -244,7 +244,7 @@ def run_pipeline(tickers: list[str] | None = None) -> int:
 
     try:
         with duckdb.connect(DB_PATH) as con:
-            enriched = enrich_reddit_posts(con, reddit_posts, tickers)
+            enriched = enrich_reddit_posts(con, reddit_posts)
             log.info(f"Reddit-Enrichment: +{enriched} Zeilen")
             trends = compute_reddit_trends(con)
             log.info(f"Trends aktualisiert: {trends}")
@@ -265,6 +265,7 @@ def run_pipeline(tickers: list[str] | None = None) -> int:
 
     # Sentiment je Ticker aus Reddit-Posts
     sentiment_frames: dict[str, pd.DataFrame] = {}
+    sentiments: dict[str, float] = {}
 
     for ticker, texts in reddit_posts.items():
         texts = list(texts) if texts is not None else []

--- a/tests/test_reddit_enrich.py
+++ b/tests/test_reddit_enrich.py
@@ -33,18 +33,18 @@ def test_enrich_reddit_posts(monkeypatch):
     }
     monkeypatch.setattr(reddit_enrich, "analyze_sentiment", lambda text: 0.5)
 
-    reddit_enrich.enrich_reddit_posts(con, posts, ["ABC"])
+    reddit_enrich.enrich_reddit_posts(con, posts)
     # second call should not create duplicates
-    reddit_enrich.enrich_reddit_posts(con, posts, ["ABC"])
+    reddit_enrich.enrich_reddit_posts(con, posts)
 
     row = con.execute(
         "SELECT id, ticker, sentiment_dict, sentiment_weighted FROM reddit_enriched"
     ).fetchone()
 
-    assert row[0] == int("abc", 36)
+    assert row[0] == "abc"
     assert row[1] == "ABC"
     assert row[2] == 0.5
-    assert row[3] == pytest.approx(0.5 * math.log(10))
+    assert row[3] == pytest.approx(0.5 * math.log1p(9))
     count = con.execute("SELECT COUNT(*) FROM reddit_enriched").fetchone()[0]
     assert count == 1
 
@@ -54,7 +54,7 @@ def test_compute_reddit_trends():
     df = pd.DataFrame(
         [
             {
-                "id": 1,
+                "id": "1",
                 "ticker": "ABC",
                 "created_utc": datetime(2024, 1, 1, 12, tzinfo=timezone.utc),
                 "text": "",
@@ -67,7 +67,7 @@ def test_compute_reddit_trends():
                 "return_7d": None,
             },
             {
-                "id": 2,
+                "id": "2",
                 "ticker": "ABC",
                 "created_utc": datetime(2024, 1, 1, 18, tzinfo=timezone.utc),
                 "text": "",
@@ -102,7 +102,7 @@ def test_compute_returns():
     post_df = pd.DataFrame(
         [
             {
-                "id": 1,
+                "id": "1",
                 "ticker": "ABC",
                 "created_utc": datetime(2024, 1, 1, tzinfo=timezone.utc),
                 "text": "",
@@ -168,7 +168,7 @@ def test_compute_returns():
     reddit_enrich.compute_returns(con)
 
     row = con.execute(
-        "SELECT return_1d, return_3d, return_7d FROM reddit_enriched WHERE id=1"
+        "SELECT return_1d, return_3d, return_7d FROM reddit_enriched WHERE id='1'"
     ).fetchone()
 
     assert row[0] == pytest.approx(0.1)

--- a/wallenstein/db_schema.py
+++ b/wallenstein/db_schema.py
@@ -19,7 +19,7 @@ SCHEMAS = {
         "upvotes": "INTEGER",
     },
     "reddit_enriched": {
-        "id": "BIGINT",
+        "id": "TEXT",
         "ticker": "TEXT",
         "created_utc": "TIMESTAMP",
         "text": "TEXT",


### PR DESCRIPTION
## Summary
- Update Reddit enrichment to accept posts without a ticker list, store string IDs, and compute weighted sentiment via `log1p`
- Switch Reddit enrichment schema to `TEXT` IDs and adjust main pipeline call
- Align tests with new string ID schema and sentiment weighting

## Testing
- `PYTHONPATH=. pytest tests/test_reddit_enrich.py -q`
- `PYTHONPATH=. pytest -q`
- `ruff check tests/test_reddit_enrich.py wallenstein/reddit_enrich.py wallenstein/db_schema.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2e96e1d488325b4f46eb3a60e36fb