### PR TITLE
Use daily sentiment table in Telegram bot

### DIFF
--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -3,7 +3,6 @@ import os
 from typing import List
 
 import duckdb
-
 from telegram import Update
 from telegram.ext import (
     ApplicationBuilder,
@@ -186,10 +185,10 @@ async def cmd_sentiment(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     with duckdb.connect(DB_PATH) as con:
         row = con.execute(
             """
-            SELECT AVG(sentiment_weighted), COUNT(*)
-            FROM reddit_enriched
-            WHERE ticker = ? AND created_utc >= CURRENT_DATE - INTERVAL 7 DAY
-              AND sentiment_weighted IS NOT NULL
+            SELECT AVG(sent_weighted_avg), SUM(post_count)
+            FROM reddit_sentiment_daily
+            WHERE ticker = ? AND date >= CURRENT_DATE - INTERVAL 7 DAY
+              AND sent_weighted_avg IS NOT NULL
             """,
             [ticker],
         ).fetchone()


### PR DESCRIPTION
## Summary
- read sentiment from `reddit_sentiment_daily` using a 7-day window
- return daily average sentiment and total post count

## Testing
- `ruff check telegram_bot.py`
- `PYTHONPATH=. pytest -q` *(fails: `TypeError: enrich_reddit_posts() takes 2 positional arguments but 3 were given` in `tests/test_reddit_enrich.py::test_enrich_reddit_posts`; `AssertionError: assert 1.0 == 0.4 ± 4.0e-07` in `tests/test_reddit_enrich.py::test_compute_returns`)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f667b9888325a5bbc32e16cbf1cc