### PR TITLE
Log hourly and daily sentiment counts

### DIFF
--- a/main.py
+++ b/main.py
@@ -256,8 +256,12 @@ def run_pipeline(tickers: list[str] | None = None) -> int:
     # Sentiment-Aggregate berechnen
     try:
         with duckdb.connect(DB_PATH) as con:
-            agg_rows = compute_reddit_sentiment_aggregates(con, backfill_days=14)
-            log.info(f"Sentiment-Aggregate aktualisiert: {agg_rows}")
+            h_count, d_count = compute_reddit_sentiment_aggregates(
+                con, backfill_days=14
+            )
+            log.info(
+                f"Sentiment-Aggregate aktualisiert: hourly rows ~{h_count}, daily rows ~{d_count}"
+            )
     except Exception as e:
         log.error(f"❌ Sentiment-Aggregate fehlgeschlagen: {e}")
 


### PR DESCRIPTION
## Summary
- Unpack hourly and daily row counts from compute_reddit_sentiment_aggregates
- Log both counts when updating sentiment aggregates

## Testing
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2f97e23b08325aeb5025f7b9ae2d1