### PR TITLE
Fix Telegram bot sentiment query to new schema

### DIFF
--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -185,10 +185,10 @@ async def cmd_sentiment(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     with duckdb.connect(DB_PATH) as con:
         row = con.execute(
             """
-            SELECT AVG(sent_weighted_avg), SUM(posts)
+            SELECT AVG(sentiment_weighted), SUM(posts)
             FROM reddit_sentiment_daily
             WHERE ticker = ? AND date >= CURRENT_DATE - INTERVAL 7 DAY
-              AND sent_weighted_avg IS NOT NULL
+              AND sentiment_weighted IS NOT NULL
             """,
             [ticker],
         ).fetchone()

--- a/wallenstein/db_schema.py
+++ b/wallenstein/db_schema.py
@@ -34,16 +34,16 @@ SCHEMAS = {
     "reddit_sentiment_hourly": {
         "created_utc": "TIMESTAMP",
         "ticker": "TEXT",
-        "sent_dict_avg": "DOUBLE",
-        "sent_weighted_avg": "DOUBLE",
-        "post_count": "INTEGER",
+        "sentiment_dict": "DOUBLE",
+        "sentiment_weighted": "DOUBLE",
+        "posts": "INTEGER",
     },
     "reddit_sentiment_daily": {
         "date": "DATE",
         "ticker": "TEXT",
-        "sent_dict_avg": "DOUBLE",
-        "sent_weighted_avg": "DOUBLE",
-        "post_count": "INTEGER",
+        "sentiment_dict": "DOUBLE",
+        "sentiment_weighted": "DOUBLE",
+        "posts": "INTEGER",
     },
     "reddit_trends": {
         "date": "DATE",
@@ -92,7 +92,7 @@ def ensure_tables(con: duckdb.DuckDBPyConnection):
         if table == "alerts":
             coldefs += ", PRIMARY KEY (id)"
         if table == "reddit_sentiment_hourly":
-            coldefs += ", PRIMARY KEY (ticker, created_utc)"
+            coldefs += ", PRIMARY KEY (created_utc, ticker)"
         if table == "reddit_sentiment_daily":
             coldefs += ", PRIMARY KEY (date, ticker)"
         con.execute(f"CREATE TABLE IF NOT EXISTS {table} ({coldefs});")


### PR DESCRIPTION
## Summary
- query `reddit_sentiment_daily` with `sentiment_weighted` column in Telegram bot
- align DB schema with new `sentiment_dict`, `sentiment_weighted`, and `posts` columns for sentiment tables

## Testing
- `ruff check telegram_bot.py wallenstein/db_schema.py`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2fb9bfdcc8325914092e5fa482ec0