### PR TITLE
Aggregate Reddit sentiment hourly and daily

### DIFF
--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -185,10 +185,10 @@ async def cmd_sentiment(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     with duckdb.connect(DB_PATH) as con:
         row = con.execute(
             """
-            SELECT AVG(sent_weighted_avg), SUM(posts)
+            SELECT AVG(sentiment_weighted), SUM(posts)
             FROM reddit_sentiment_daily
             WHERE ticker = ? AND date >= CURRENT_DATE - INTERVAL 7 DAY
-              AND sent_weighted_avg IS NOT NULL
+              AND sentiment_weighted IS NOT NULL
             """,
             [ticker],
         ).fetchone()

--- a/wallenstein/db_schema.py
+++ b/wallenstein/db_schema.py
@@ -34,16 +34,16 @@ SCHEMAS = {
     "reddit_sentiment_hourly": {
         "created_utc": "TIMESTAMP",
         "ticker": "TEXT",
-        "sent_dict_avg": "DOUBLE",
-        "sent_weighted_avg": "DOUBLE",
-        "post_count": "INTEGER",
+        "sentiment_dict": "DOUBLE",
+        "sentiment_weighted": "DOUBLE",
+        "posts": "INTEGER",
     },
     "reddit_sentiment_daily": {
         "date": "DATE",
         "ticker": "TEXT",
-        "sent_dict_avg": "DOUBLE",
-        "sent_weighted_avg": "DOUBLE",
-        "post_count": "INTEGER",
+        "sentiment_dict": "DOUBLE",
+        "sentiment_weighted": "DOUBLE",
+        "posts": "INTEGER",
     },
     "reddit_trends": {
         "date": "DATE",


### PR DESCRIPTION
## Summary
- align Telegram `/sentiment` command with new aggregated sentiment columns
- update DB schema for hourly/daily sentiment tables to use `sentiment_*` and `posts`

## Testing
- `ruff check telegram_bot.py wallenstein/db_schema.py`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2fbbdfc4c8325b462a0f19ed01397