### PR TITLE
Capture inserted alias counts when seeding

### DIFF
--- a/wallenstein/aliases.py
+++ b/wallenstein/aliases.py
@@ -31,8 +31,13 @@ def seed_from_json(con: duckdb.DuckDBPyConnection) -> int:
             rows.append((tkr.upper(), a, "seed"))
     if not rows:
         return 0
-    con.executemany("INSERT OR IGNORE INTO ticker_aliases (ticker, alias, source) VALUES (?, ?, ?)", rows)
-    return len(rows)
+    pre_count = con.execute("SELECT COUNT(*) FROM ticker_aliases").fetchone()[0]
+    con.executemany(
+        "INSERT OR IGNORE INTO ticker_aliases (ticker, alias, source) VALUES (?, ?, ?)",
+        rows,
+    )
+    post_count = con.execute("SELECT COUNT(*) FROM ticker_aliases").fetchone()[0]
+    return post_count - pre_count
 
 def add_alias(con: duckdb.DuckDBPyConnection, ticker: str, alias: str, source="manual") -> bool:
     ensure_table(con)

--- a/wallenstein/db.py
+++ b/wallenstein/db.py
@@ -65,10 +65,10 @@ def init_schema(db_path: str | None = None) -> None:
     try:
         import duckdb
         with duckdb.connect(db_path or settings.WALLENSTEIN_DB_PATH) as con:
-            n = seed_from_json(con)
-            if n:
+            new_rows = seed_from_json(con)
+            if new_rows:
                 log = logging.getLogger("wallenstein")
-                log.info(f"Aliase aus JSON importiert: {n}")
+                log.info(f"Aliase aus JSON importiert: {new_rows} neue Zeilen")
     except Exception as e:  # pragma: no cover - best effort
         logging.getLogger("wallenstein").warning(
             f"Alias-Seed übersprungen: {e}"


### PR DESCRIPTION
## Summary
- track table counts before and after seeding ticker aliases to report real number of new rows
- log how many alias rows were newly inserted from JSON seed

## Testing
- `PYTHONPATH=. pytest` *(fails: duckdb.duckdb.BinderException: Referenced column "sentiment_dict" not found in FROM clause)*

------
https://chatgpt.com/codex/tasks/task_e_68b310ee31488325903744f926d48955