### PR TITLE
Add multilingual sentiment engine and improve imbalance handling

### DIFF
--- a/.github/workflows/wallenstein.yml
+++ b/.github/workflows/wallenstein.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   run:
+    concurrency:
+      group: wallenstein-${{ github.ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     timeout-minutes: 25
     env:
@@ -21,6 +24,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+          cache: 'pip'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -32,3 +36,17 @@ jobs:
           if [ -f .env ]; then rm .env; fi
       - name: Run pipeline
         run: python main.py
+      - name: Notify Telegram on failure
+        if: ${{ failure() && secrets.TELEGRAM_BOT_TOKEN != '' && secrets.TELEGRAM_CHAT_ID != '' }}
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID:   ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: |
+          python - <<'PY'
+import os, requests
+tok=os.environ.get("TELEGRAM_BOT_TOKEN","")
+cid=os.environ.get("TELEGRAM_CHAT_ID","")
+if tok and cid:
+    requests.get(f"https://api.telegram.org/bot{tok}/sendMessage",
+        params={"chat_id":cid,"text":"Wallenstein CI failed 🚨"})
+PY

--- a/README.md
+++ b/README.md
@@ -121,6 +121,25 @@ If the file exists it is loaded on import and merged with the default
 mapping. Custom keywords therefore influence all subsequent calls to
 ``analyze_sentiment``.
 
+## Sentiment Engine (Multilingual + Keyword-Boosts + Weighted Aggregation)
+
+Reddit posts are cleaned (links, handles and simple markdown removed) and
+lower‑cased before sentiment analysis. When the optional `transformers` package
+is available the engine uses the multilingual
+`cardiffnlp/twitter-xlm-roberta-base-sentiment` model to obtain probabilities
+for negative, neutral and positive labels. If `transformers` or its
+dependencies are missing, the system falls back to NLTK's VADER lexicon, which
+is downloaded automatically when needed.
+
+Simple keyword boosts adjust the score (`+0.2` for "long"/"call", `-0.2` for
+"short"/"put" with a cap of ±0.4). Each post receives a weight of
+`1 + log10(1+upvotes) + 0.2*log10(1+num_comments)`. Scores are aggregated per
+ticker and day (mean, weighted mean and median) and stored in DuckDB's
+`reddit_daily_sentiment` table.
+
+The sentiment engine runs without `transformers` or `torch`; in that case the
+VADER path is used transparently.
+
 ## Dynamic Watchlist + Telegram Bot
 
 Expose ``TELEGRAM_BOT_TOKEN`` and ``TELEGRAM_CHAT_ID`` (override the database path with ``WALLENSTEIN_DB_PATH`` if needed) and start the bot with:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,9 @@ python-dotenv
 praw
 scikit-learn
 pyyaml
-imbalanced-learn
+imbalanced-learn>=0.12
+langdetect>=1.0.9
+transformers>=4.41
 optuna
 optuna-integration[sklearn]
 

--- a/wallenstein/db.py
+++ b/wallenstein/db.py
@@ -54,22 +54,20 @@ def init_schema(db_path: str | None = None) -> None:
         )
         """
         )
-        con.execute(
-            "CREATE INDEX IF NOT EXISTS idx_ticker_aliases_alias ON ticker_aliases(alias)"
-        )
-        con.execute(
-            "CREATE INDEX IF NOT EXISTS idx_ticker_aliases_tkr ON ticker_aliases(ticker)"
-        )
+        con.execute("CREATE INDEX IF NOT EXISTS idx_ticker_aliases_alias ON ticker_aliases(alias)")
+        con.execute("CREATE INDEX IF NOT EXISTS idx_ticker_aliases_tkr ON ticker_aliases(ticker)")
+        con.execute("CREATE INDEX IF NOT EXISTS idx_alias_lower ON ticker_aliases(LOWER(alias))")
+        con.execute("CREATE INDEX IF NOT EXISTS idx_name_lower ON ticker_aliases(LOWER(ticker))")
 
     from wallenstein.aliases import seed_from_json
+
     try:
         import duckdb
+
         with duckdb.connect(db_path or settings.WALLENSTEIN_DB_PATH) as con:
             new_rows = seed_from_json(con)
             if new_rows:
                 log = logging.getLogger("wallenstein")
                 log.info(f"Aliase aus JSON importiert: {new_rows} neue Zeilen")
     except Exception as e:  # pragma: no cover - best effort
-        logging.getLogger("wallenstein").warning(
-            f"Alias-Seed übersprungen: {e}"
-        )
+        logging.getLogger("wallenstein").warning(f"Alias-Seed übersprungen: {e}")

--- a/wallenstein/db_schema.py
+++ b/wallenstein/db_schema.py
@@ -34,16 +34,16 @@ SCHEMAS = {
     "reddit_sentiment_hourly": {
         "created_utc": "TIMESTAMP",
         "ticker": "TEXT",
-        "sent_dict_avg": "DOUBLE",
-        "sent_weighted_avg": "DOUBLE",
-        "post_count": "INTEGER",
+        "sentiment_dict": "DOUBLE",
+        "sentiment_weighted": "DOUBLE",
+        "posts": "INTEGER",
     },
     "reddit_sentiment_daily": {
         "date": "DATE",
         "ticker": "TEXT",
-        "sent_dict_avg": "DOUBLE",
-        "sent_weighted_avg": "DOUBLE",
-        "post_count": "INTEGER",
+        "sentiment_dict": "DOUBLE",
+        "sentiment_weighted": "DOUBLE",
+        "posts": "INTEGER",
     },
     "reddit_trends": {
         "date": "DATE",
@@ -133,9 +133,7 @@ def ensure_tables(con: duckdb.DuckDBPyConnection):
             col_types = {row[1]: row[2].upper() for row in info}
             if col_types.get("id") != "VARCHAR":
                 try:
-                    con.execute(
-                        "ALTER TABLE reddit_enriched ALTER COLUMN id SET DATA TYPE VARCHAR"
-                    )
+                    con.execute("ALTER TABLE reddit_enriched ALTER COLUMN id SET DATA TYPE VARCHAR")
                 except duckdb.Error:
                     pass
             try:
@@ -173,7 +171,6 @@ def ensure_tables(con: duckdb.DuckDBPyConnection):
             con.execute(
                 "CREATE UNIQUE INDEX IF NOT EXISTS fx_rates_date_pair_idx ON fx_rates(date, pair)"
             )
-
 
 
 def validate_df(df, table_name: str):

--- a/wallenstein/sentiment_analysis.py
+++ b/wallenstein/sentiment_analysis.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import logging
+import math
+import re
+from dataclasses import dataclass
+from typing import Any
+
+log = logging.getLogger("wallenstein")
+
+# --- Keyword-Boosts (konfigurierbar) ---
+POS_BOOST = {"long": 0.2, "call": 0.2}
+NEG_BOOST = {"short": -0.2, "put": -0.2}
+MAX_ABS_KEYWORD = 0.4
+
+
+# --- Lazy imports / fallbacks ---
+def _try_import_transformers():
+    try:
+        from transformers import pipeline  # type: ignore
+
+        return pipeline
+    except Exception:
+        return None
+
+
+def _ensure_vader():
+    try:
+        from nltk.sentiment import SentimentIntensityAnalyzer  # type: ignore
+
+        return SentimentIntensityAnalyzer
+    except Exception:
+        try:
+            import nltk
+
+            nltk.download("vader_lexicon", quiet=True)
+            from nltk.sentiment import SentimentIntensityAnalyzer
+
+            return SentimentIntensityAnalyzer
+        except Exception as e2:  # pragma: no cover - best effort
+            log.warning(f"VADER not available: {e2}")
+            return None
+
+
+def _detect_lang(text: str) -> str:
+    try:
+        from langdetect import detect  # type: ignore
+
+        return detect(text)
+    except Exception:
+        return "en"
+
+
+_clean_re = re.compile(r"(https?://\S+)|(@\w+)|[#*_>`]|(&amp;)|\s+")
+
+
+def preprocess(text: str) -> str:
+    if not text:
+        return ""
+    t = text.replace("\n", " ")
+    t = _clean_re.sub(" ", t)
+    t = t.strip().lower()
+    return t
+
+
+@dataclass
+class SentimentResult:
+    score: float  # [-1, 1]
+    method: str
+    meta: dict[str, Any]
+
+
+class SentimentEngine:
+    def __init__(self) -> None:
+        self._hf = None
+        self._vader = None
+        self._setup()
+
+    def _setup(self) -> None:
+        pipeline = _try_import_transformers()
+        if pipeline:
+            try:
+                self._hf = pipeline(
+                    "sentiment-analysis",
+                    model="cardiffnlp/twitter-xlm-roberta-base-sentiment",
+                )
+                log.info("Sentiment: using HF xlm-roberta pipeline")
+            except Exception as e:  # pragma: no cover - best effort
+                log.warning(f"HF pipeline unavailable: {e}")
+        SIA = _ensure_vader()
+        if SIA:
+            try:
+                self._vader = SIA()
+                log.info("Sentiment: VADER ready (fallback)")
+            except Exception as e:  # pragma: no cover - best effort
+                log.warning(f"VADER init failed: {e}")
+
+    def _keyword_boost(self, text: str) -> float:
+        if not text:
+            return 0.0
+        boost = 0.0
+        for k, v in POS_BOOST.items():
+            if k in text:
+                boost += v
+        for k, v in NEG_BOOST.items():
+            if k in text:
+                boost += v
+        return max(-MAX_ABS_KEYWORD, min(MAX_ABS_KEYWORD, boost))
+
+    def analyze(self, raw_text: str) -> SentimentResult:
+        txt = preprocess(raw_text)
+        if not txt:
+            return SentimentResult(0.0, "empty", {})
+
+        lang = _detect_lang(txt)
+        kw = self._keyword_boost(txt)
+
+        if self._hf and lang in {"de", "fr", "es", "it", "en"}:
+            try:
+                out = self._hf(txt, top_k=None, truncation=True)
+                if out and isinstance(out, list):
+                    by = {
+                        d["label"].lower(): d["score"] for d in out if "label" in d and "score" in d
+                    }
+                    pos = by.get("positive", 0.0)
+                    neu = by.get("neutral", 0.0)
+                    neg = by.get("negative", 0.0)
+                    score = pos * 1.0 + neu * 0.0 + neg * (-1.0)
+                    score = max(-1.0, min(1.0, score + kw))
+                    return SentimentResult(
+                        score, "hf-xlm-roberta", {"lang": lang, "scores": by, "kw": kw}
+                    )
+            except Exception as e:  # pragma: no cover - best effort
+                log.debug(f"HF inference failed, fallback to VADER: {e}")
+
+        if self._vader:
+            pol = self._vader.polarity_scores(txt)
+            score = pol.get("compound", 0.0)
+            score = max(-1.0, min(1.0, score + kw))
+            return SentimentResult(score, "vader", {"lang": lang, "polarity": pol, "kw": kw})
+
+        return SentimentResult(0.0 + kw, "rule-only", {"lang": lang, "kw": kw})
+
+
+engine_singleton: SentimentEngine | None = None
+
+
+def analyze_sentiment(text: str) -> float:
+    global engine_singleton
+    if engine_singleton is None:
+        engine_singleton = SentimentEngine()
+    return engine_singleton.analyze(text).score
+
+
+def post_weight(upvotes: int = 0, num_comments: int = 0) -> float:
+    return 1.0 + math.log10(1 + max(0, upvotes)) + 0.2 * math.log10(1 + max(0, num_comments))
+
+
+__all__ = ["analyze_sentiment", "post_weight", "SentimentEngine", "SentimentResult"]


### PR DESCRIPTION
## Summary
- add optional transformers/langdetect/imbalanced-learn requirements
- guard SMOTE/undersample and cap CV splits for class imbalance
- aggregate multilingual sentiment daily and persist with weighted keywords
- harden CI with concurrency, pip caching and conditional Telegram alerts

## Testing
- `pre-commit run --files requirements.txt wallenstein/models.py wallenstein/reddit_scraper.py .github/workflows/wallenstein.yml wallenstein/sentiment_analysis.py main.py wallenstein/db.py README.md`
- `pre-commit run --files wallenstein/db_schema.py`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b3169c33a08325ba2af91395f2e100