### PR TITLE
Fix HF sentiment score mapping

### DIFF
--- a/wallenstein/sentiment_analysis.py
+++ b/wallenstein/sentiment_analysis.py
@@ -119,8 +119,11 @@ class SentimentEngine:
             try:
                 out = self._hf(txt, top_k=None, truncation=True)
                 if out and isinstance(out, list):
+                    scores = out[0] if out and isinstance(out[0], list) else out
                     by = {
-                        d["label"].lower(): d["score"] for d in out if "label" in d and "score" in d
+                        d["label"].lower(): d["score"]
+                        for d in scores
+                        if isinstance(d, dict) and "label" in d and "score" in d
                     }
                     pos = by.get("positive", 0.0)
                     neu = by.get("neutral", 0.0)


### PR DESCRIPTION
## Summary
- flatten HF pipeline output before computing sentiment

## Testing
- `python -m pre_commit run --files wallenstein/sentiment_analysis.py`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b346fc6c148325877cc0e7edafdbaa