### PR TITLE
Handle offline VADER lexicon availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Broker-target support is temporarily disabled pending a new data provider.
 ## Quickstart
 ```bash
 pip install -r requirements.txt
+python -c "import nltk; nltk.download('vader_lexicon')"  # pre-install VADER lexicon
 cp .env.example .env   # and fill values
 python main.py
 python -m bot.telegram_bot  # optional: manage watchlist via Telegram
@@ -128,8 +129,9 @@ lower‑cased before sentiment analysis. When the optional `transformers` packag
 is available the engine uses the multilingual
 `cardiffnlp/twitter-xlm-roberta-base-sentiment` model to obtain probabilities
 for negative, neutral and positive labels. If `transformers` or its
-dependencies are missing, the system falls back to NLTK's VADER lexicon, which
-is downloaded automatically when needed.
+dependencies are missing, the system falls back to NLTK's VADER lexicon. The
+lexicon downloads automatically when online; to prepare an offline environment
+run `python -c "import nltk; nltk.download('vader_lexicon')"` ahead of time.
 
 Simple keyword boosts adjust the score (`+0.2` for "long"/"call", `-0.2` for
 "short"/"put" with a cap of ±0.4). Each post receives a weight of

--- a/wallenstein/sentiment_analysis.py
+++ b/wallenstein/sentiment_analysis.py
@@ -4,8 +4,9 @@ import logging
 import math
 import os
 import re
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Callable, Optional
+from typing import Any
 
 log = logging.getLogger("wallenstein")
 
@@ -17,35 +18,54 @@ MAX_ABS_KEYWORD = 0.4
 # Für stabilere Tokenizer-Läufe in CI
 os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
 
+
 # --------------------------
 # Lazy imports / fallbacks
 # --------------------------
 def _try_import_transformers():
     try:
         from transformers import pipeline  # type: ignore
+
         return pipeline
     except Exception:
         return None
 
 
+def _has_internet() -> bool:
+    try:  # pragma: no cover - simple connectivity check
+        import urllib.request
+
+        urllib.request.urlopen("https://www.nltk.org", timeout=1)
+        return True
+    except Exception:
+        return False
+
+
 def _ensure_vader():
     try:
+        import nltk  # type: ignore
         from nltk.sentiment import SentimentIntensityAnalyzer  # type: ignore
-        return SentimentIntensityAnalyzer
-    except Exception:
+
         try:
-            import nltk  # type: ignore
-            nltk.download("vader_lexicon", quiet=True)
-            from nltk.sentiment import SentimentIntensityAnalyzer  # type: ignore
-            return SentimentIntensityAnalyzer
-        except Exception as e2:  # pragma: no cover
-            log.warning(f"VADER not available: {e2}")
-            return None
+            nltk.data.find("sentiment/vader_lexicon.zip")
+        except LookupError:
+            if _has_internet():
+                try:
+                    nltk.download("vader_lexicon", quiet=True)
+                except Exception:
+                    pass
+            nltk.data.find("sentiment/vader_lexicon.zip")
+
+        return SentimentIntensityAnalyzer
+    except Exception as e2:  # pragma: no cover
+        log.warning("VADER not available: %s", str(e2).splitlines()[0])
+        return None
 
 
 def _detect_lang(text: str) -> str:
     try:
         from langdetect import detect  # type: ignore
+
         return detect(text)
     except Exception:
         # Fallback: Englisch annehmen
@@ -53,6 +73,8 @@ def _detect_lang(text: str) -> str:
 
 
 _clean_re = re.compile(r"(https?://\S+)|(@\w+)|[#*`>|]|(&amp;)|\s+")
+
+
 # Cashtags ($NVDA) und Zahlen/Buchstaben bleiben erhalten.
 def preprocess(text: str) -> str:
     if not text:
@@ -111,8 +133,8 @@ class SentimentEngine:
 
     def __init__(self) -> None:
         self._pipeline = _try_import_transformers()
-        self._hf_finbert: Optional[Callable] = None
-        self._hf_xlmr: Optional[Callable] = None
+        self._hf_finbert: Callable | None = None
+        self._hf_xlmr: Callable | None = None
         self._vader = None
         self._setup_vader()
 
@@ -194,10 +216,16 @@ class SentimentEngine:
                 if pipe:
                     out = pipe(txt)
                     # pipeline gibt List[ List[dict] ] oder List[dict]; normal: List[dict]
-                    scores = out[0] if (isinstance(out, list) and out and isinstance(out[0], dict)) else out
+                    scores = (
+                        out[0]
+                        if (isinstance(out, list) and out and isinstance(out[0], dict))
+                        else out
+                    )
                     scalar, by = self._scores_to_scalar(scores)  # type: ignore[arg-type]
                     score = max(-1.0, min(1.0, scalar + kw))
-                    return SentimentResult(score, f"hf:{model_id}", {"lang": lang, "scores": by, "kw": kw})
+                    return SentimentResult(
+                        score, f"hf:{model_id}", {"lang": lang, "scores": by, "kw": kw}
+                    )
             except Exception as e:  # pragma: no cover
                 log.debug(f"HF inference failed, fallback to VADER: {e}")
 


### PR DESCRIPTION
## Summary
- Avoid VADER download attempts when offline by checking for an existing lexicon first
- Log a single-line warning when VADER cannot be used
- Document how to pre-install the VADER lexicon during setup

## Testing
- `pre-commit run --files wallenstein/sentiment_analysis.py README.md`
- `pytest` *(fails: No module named 'wallenstein')*


------
https://chatgpt.com/codex/tasks/task_e_68b49f1e0904832584b7d99c00e77f24