### PR TITLE
Handle NaN upvote counts in sentiment aggregation

### DIFF
--- a/main.py
+++ b/main.py
@@ -164,9 +164,11 @@ def aggregate_daily_sentiment(posts: pd.DataFrame) -> pd.DataFrame:
     posts = posts.copy()
     posts["text"] = posts["title"].fillna("") + " " + posts["selftext"].fillna("")
     posts["sentiment"] = posts["text"].map(analyze_sentiment)
-    posts["weight"] = posts.apply(
-        lambda r: post_weight(int(r.get("ups", 0)), int(r.get("num_comments", 0))), axis=1
+    posts["ups"] = pd.to_numeric(posts["ups"], errors="coerce").fillna(0).astype(int)
+    posts["num_comments"] = (
+        pd.to_numeric(posts["num_comments"], errors="coerce").fillna(0).astype(int)
     )
+    posts["weight"] = posts.apply(lambda r: post_weight(r["ups"], r["num_comments"]), axis=1)
     posts["date"] = pd.to_datetime(posts["created_utc"], unit="s").dt.tz_localize("UTC").dt.date
     agg = (
         posts.groupby(["date", "ticker"])

--- a/tests/test_sentiment_aggregation.py
+++ b/tests/test_sentiment_aggregation.py
@@ -1,0 +1,54 @@
+import os
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+# provide minimal config for main.validate_config
+os.environ.setdefault("REDDIT_CLIENT_ID", "test")
+os.environ.setdefault("REDDIT_CLIENT_SECRET", "test")
+os.environ.setdefault("REDDIT_USER_AGENT", "test")
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import importlib
+
+import wallenstein.sentiment as sentiment
+
+
+@pytest.fixture(autouse=True)
+def _disable_bert(monkeypatch):
+    """Ensure keyword-based sentiment to keep tests light."""
+    monkeypatch.setattr(sentiment.settings, "USE_BERT_SENTIMENT", False)
+
+
+def test_aggregate_handles_nan_values():
+    main = importlib.import_module("main")
+
+    posts = pd.DataFrame(
+        [
+            {
+                "created_utc": 1_700_000_000,
+                "ticker": "ABC",
+                "title": "bullish",
+                "selftext": "",
+                "ups": float("nan"),
+                "num_comments": float("nan"),
+            },
+            {
+                "created_utc": 1_700_000_000,
+                "ticker": "ABC",
+                "title": "bearish",
+                "selftext": "",
+                "ups": 5,
+                "num_comments": float("nan"),
+            },
+        ]
+    )
+
+    agg = main.aggregate_daily_sentiment(posts)
+
+    assert agg.loc[0, "n_posts"] == 2
+    assert not agg["sentiment_weighted"].isna().any()


### PR DESCRIPTION
## Summary
- sanitize `ups` and `num_comments` using `pd.to_numeric(...).fillna(0).astype(int)`
- recompute `weight` from sanitized counts
- add regression test for sentiment aggregation with NaN post counts

## Testing
- `pre-commit run --files main.py tests/test_sentiment_aggregation.py`
- `pytest tests/test_sentiment_aggregation.py`


------
https://chatgpt.com/codex/tasks/task_e_68b49f1c808c8325ac6a2d07f33e9b1c