### PR TITLE
Use top_k for HF sentiment pipeline

### DIFF
--- a/tests/test_sentiment.py
+++ b/tests/test_sentiment.py
@@ -22,6 +22,7 @@ from wallenstein.sentiment import (
 def _disable_bert(monkeypatch):
     """Use keyword sentiment by default for tests."""
     monkeypatch.setattr(sentiment.settings, "USE_BERT_SENTIMENT", False)
+    sentiment._bert_analyzer = None
 
 def test_analyze_sentiment_keywords():
     text = "I'm going long and want to buy more calls, not sell"

--- a/tests/test_sentiment_analysis.py
+++ b/tests/test_sentiment_analysis.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from wallenstein.sentiment_analysis import SentimentEngine
+
+
+def test_pipeline_uses_top_k_none(monkeypatch):
+    captured = {}
+
+    class DummyPipeline:
+        def __init__(self, *args, **kwargs):
+            captured["top_k"] = kwargs.get("top_k")
+
+        def __call__(self, text):
+            return [[{"label": "positive", "score": 0.8}, {"label": "negative", "score": 0.2}]]
+
+    monkeypatch.setattr("wallenstein.sentiment_analysis._try_import_transformers", lambda: DummyPipeline)
+    monkeypatch.setattr("wallenstein.sentiment_analysis._ensure_vader", lambda: None)
+    monkeypatch.setattr("wallenstein.sentiment_analysis._detect_lang", lambda text: "en")
+    engine = SentimentEngine()
+    res = engine.analyze("good")
+    assert captured["top_k"] is None
+    assert res.meta["scores"]["positive"] == pytest.approx(0.8, abs=0.01)
+    assert res.meta["scores"]["negative"] == pytest.approx(0.2, abs=0.01)


### PR DESCRIPTION
## Summary
- switch sentiment analysis pipelines to `top_k=None` for full label scores
- handle nested pipeline output so downstream code sees all scores
- add regression test for `top_k=None` usage and reset BERT analyzer during tests

## Testing
- `pre-commit run --files wallenstein/sentiment_analysis.py tests/test_sentiment_analysis.py tests/test_sentiment.py`
- `pytest tests/test_sentiment_analysis.py tests/test_sentiment.py`


------
https://chatgpt.com/codex/tasks/task_e_68b49f1d68dc8325ab7b5b1316b806c8