### PR TITLE
Reuse sessions for Stooq requests

### DIFF
--- a/tests/test_stock_data.py
+++ b/tests/test_stock_data.py
@@ -13,7 +13,7 @@ def test_update_prices_fetches_full_history_for_new_ticker(monkeypatch, tmp_path
     db = tmp_path / "prices.duckdb"
     called = {}
 
-    def fake_fetch_one(ticker, start=None):
+    def fake_fetch_one(ticker, start=None, session=None):
         called["start"] = start
         return pd.DataFrame({
             "date": pd.to_datetime(["2024-01-02", "2024-01-03"]),
@@ -50,7 +50,7 @@ def test_update_prices_skips_weekend(monkeypatch, tmp_path, caplog):
 
     called = {"stooq": 0}
 
-    def fake_fetch_one(ticker, start=None):
+    def fake_fetch_one(ticker, start=None, session=None):
         called["stooq"] += 1
         return pd.DataFrame()
 


### PR DESCRIPTION
## Summary
- reuse a requests session per thread when fetching Stooq data
- pass session instances through `_stooq_fetch_many` and `_stooq_fetch_one`
- adjust tests for updated signature

## Testing
- `PYTHONPATH=. pytest tests/test_stock_data.py`
- `PYTHONPATH=. pytest` *(fails: tests/test_sentiment_analysis.py::test_pipeline_uses_top_k_none - KeyError: 'positive')*
- `ruff check wallenstein/stock_data.py tests/test_stock_data.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4a2bc60c08325b1d17da786f5b253