### PR TITLE
Refactor ticker matching and batch sentiment

### DIFF
--- a/tests/test_reddit_scraper.py
+++ b/tests/test_reddit_scraper.py
@@ -127,7 +127,7 @@ def test_sentiment_added_to_buckets(monkeypatch):
     monkeypatch.setattr(reddit_scraper, "fetch_reddit_posts", lambda *a, **k: df)
     monkeypatch.setattr(reddit_scraper, "_load_posts_from_db", lambda: df)
     monkeypatch.setattr(reddit_scraper, "purge_old_posts", lambda: None)
-    monkeypatch.setattr(reddit_scraper, "analyze_sentiment", lambda text: 0.5)
+    monkeypatch.setattr(reddit_scraper, "analyze_sentiment_batch", lambda texts: [0.5 for _ in texts])
 
     out = reddit_scraper.update_reddit_data(["ABC"], subreddits=None)
     assert out["ABC"][0]["sentiment"] == 0.5

--- a/wallenstein/sentiment_analysis.py
+++ b/wallenstein/sentiment_analysis.py
@@ -228,18 +228,16 @@ class SentimentEngine:
 
                 if pipe:
                     out = pipe(txt)
-                    # pipeline gibt List[List[dict]] oder List[dict]; normal: List[dict]
-                    if isinstance(out, list) and out and isinstance(out[0], (list, tuple)):
-                        scores = out[0]
+                    if isinstance(out, list) and out:
+                        first = out[0]
+                        if isinstance(first, dict):
+                            scores = out
+                        elif isinstance(first, (list, tuple)):
+                            scores = first
+                        else:
+                            scores = out
                     else:
                         scores = out
-
-                    # pipeline gibt List[ List[dict] ] oder List[dict]; normal: List[dict]
-                    scores = (
-                        out[0]
-                        if (isinstance(out, list) and out and isinstance(out[0], dict))
-                        else out
-                    )
 
                     scalar, by = self._scores_to_scalar(scores)  # type: ignore[arg-type]
                     score = max(-1.0, min(1.0, scalar + kw))


### PR DESCRIPTION
## Summary
- detect tickers in a single pass and add boolean columns for matched symbols
- gather posts per ticker via these boolean columns and score sentiments in batch
- handle transformer pipeline outputs that return nested lists

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4a2b87b10832590a385e41b4206f0