### PR TITLE
Vectorize Reddit post weighting

### DIFF
--- a/main.py
+++ b/main.py
@@ -190,6 +190,17 @@ def aggregate_daily_sentiment(posts: pd.DataFrame) -> pd.DataFrame:
     agg["sentiment_weighted"] = agg["sent_w_sum"] / agg["weight_sum"].clip(lower=1e-9)
     agg = agg.drop(columns=["sent_w_sum", "weight_sum"])
     agg["updated_at"] = datetime.now(timezone.utc)
+    agg = agg[
+        [
+            "date",
+            "ticker",
+            "n_posts",
+            "sentiment_mean",
+            "sentiment_weighted",
+            "sentiment_median",
+            "updated_at",
+        ]
+    ]
     return agg
 
 


### PR DESCRIPTION
## Summary
- replace per-row post weight with vectorized log-based formula
- aggregate weighted sentiment via precomputed sums instead of groupby.apply
- restore reddit sentiment column order to match DB schema

## Testing
- `ruff check main.py`
- `PYTHONPATH=. pytest -q` *(fails: KeyError: 'positive')*

------
https://chatgpt.com/codex/tasks/task_e_68b4a43bd70483259c813f6370a8ef92