### PR TITLE
Normalize keyword sentiment loading

### DIFF
--- a/data/sentiment_keywords.json
+++ b/data/sentiment_keywords.json
@@ -14,10 +14,14 @@
   "benefit": 1,
   "betrug": -1,
   "caution": -1,
+  "chance": 1,
+  "danger": -1,
   "enttäuscht": -1,
+  "erfolg": 1,
   "erfolgreich": 1,
   "fail": -1,
   "fantastisch": 1,
+  "gefahr": -1,
   "glücklich": 1,
   "grandios": 1,
   "growth": 1,
@@ -25,6 +29,7 @@
   "improve": 1,
   "katastrophe": -1,
   "liability": -1,
+  "opportunity": 1,
   "pleite": -1,
   "profitability": 1,
   "risk": -1,
@@ -40,3 +45,4 @@
   "zufrieden": 1,
   "überragend": 1
 }
+

--- a/tests/test_sentiment.py
+++ b/tests/test_sentiment.py
@@ -125,7 +125,8 @@ def test_keywords_loaded_from_file():
         kw_file.write_text(json.dumps({"superbull": 1, "schrott": -1}))
         importlib.reload(sentiment)
         assert sentiment.KEYWORD_SCORES["superbull"] == 1
-        assert sentiment.KEYWORD_SCORES["schrott"] == -1
+        norm = sentiment.normalize_token("schrott")
+        assert sentiment.KEYWORD_SCORES[norm] == -1
     finally:
         if original is None:
             kw_file.unlink()

--- a/wallenstein/sentiment.py
+++ b/wallenstein/sentiment.py
@@ -250,7 +250,8 @@ def _load_keywords_from_file(
     if keywords:
         for word, score in keywords.items():
             try:
-                KEYWORD_SCORES.setdefault(str(word).lower(), int(score))
+                norm = normalize_token(str(word).lower())
+                KEYWORD_SCORES.setdefault(norm, int(score))
             except Exception:
                 continue
 
@@ -280,7 +281,8 @@ def _load_keywords_from_file(
 
             for word, score in (data or {}).items():
                 try:
-                    KEYWORD_SCORES.setdefault(str(word).lower(), int(score))
+                    norm = normalize_token(str(word).lower())
+                    KEYWORD_SCORES.setdefault(norm, int(score))
                 except Exception:
                     continue
         except Exception as exc:  # pragma: no cover - defensive


### PR DESCRIPTION
## Summary
- Normalize keywords when loading additional sentiment mappings
- Add synonym entries to sentiment keywords list
- Adjust tests for normalized keyword insertion

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4abb63a7483258a99da5de9eaa21c