### PR TITLE
Chunk sentiment batches to avoid memory spikes

### DIFF
--- a/main.py
+++ b/main.py
@@ -165,7 +165,10 @@ def aggregate_daily_sentiment(posts: pd.DataFrame) -> pd.DataFrame:
         )
     posts = posts.copy()
     posts["text"] = posts["title"].fillna("") + " " + posts["selftext"].fillna("")
-    scores = analyze_sentiment_batch(posts["text"].astype(str).tolist())
+    texts = posts["text"].astype(str).tolist()
+    scores: list[float | None] = []
+    for i in range(0, len(texts), 64):
+        scores.extend(analyze_sentiment_batch(texts[i : i + 64]))
     posts["sentiment"] = [0.0 if s is None else float(s) for s in scores]
     posts["ups"] = pd.to_numeric(posts["ups"], errors="coerce").fillna(0).astype(int)
     posts["num_comments"] = (


### PR DESCRIPTION
## Summary
- Process daily sentiment in smaller batches to avoid large tensor allocations.

## Testing
- `ruff check main.py`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4ad4ca49483258011b869a795f6c2