### PR TITLE
Add daily sentiment to overview

### DIFF
--- a/wallenstein/overview.py
+++ b/wallenstein/overview.py
@@ -103,6 +103,16 @@ def generate_overview(
             lines.append(f"Sentiment (7d, weighted): {w_sent:+.2f}")
 
             try:
+                sent_row_1d = con.execute(
+                    "SELECT sentiment_weighted FROM reddit_sentiment_daily WHERE ticker=? ORDER BY date DESC LIMIT 1",
+                    [t],
+                ).fetchone()
+            except duckdb.Error:
+                sent_row_1d = None
+            if sent_row_1d and sent_row_1d[0] is not None:
+                lines.append(f"Sentiment (1d, weighted): {sent_row_1d[0]:+.2f}")
+
+            try:
                 sent_row_24h = con.execute(
                     """
                     SELECT AVG(sentiment_weighted) AS w


### PR DESCRIPTION
## Summary
- query latest daily weighted sentiment for each ticker and display it in overview
- test that overview includes the daily weighted sentiment line

## Testing
- `ruff check wallenstein/overview.py tests/test_overview.py`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b86402c31c832592f0b80607713051