### PR TITLE
fix: recompute reddit sentiment weights

### DIFF
--- a/tests/test_reddit_enrich.py
+++ b/tests/test_reddit_enrich.py
@@ -73,7 +73,8 @@ def test_compute_reddit_trends():
                 "text": "",
                 "upvotes": 3,
                 "sentiment_dict": 0.2,
-                "sentiment_weighted": 0.2,
+                # simulate legacy rows weighted via log1p(upvotes)
+                "sentiment_weighted": 0.0,
                 "sentiment_ml": None,
                 "return_1d": None,
                 "return_3d": None,
@@ -187,7 +188,8 @@ def test_compute_reddit_sentiment():
                 "text": "",
                 "upvotes": 0,
                 "sentiment_dict": 0.2,
-                "sentiment_weighted": 0.2,
+                # simulate legacy rows weighted via log1p(upvotes)
+                "sentiment_weighted": 0.0,
                 "sentiment_ml": None,
                 "return_1d": None,
                 "return_3d": None,
@@ -200,7 +202,8 @@ def test_compute_reddit_sentiment():
                 "text": "",
                 "upvotes": 0,
                 "sentiment_dict": 0.4,
-                "sentiment_weighted": 0.4,
+                # simulate legacy rows weighted via log1p(upvotes)
+                "sentiment_weighted": 0.0,
                 "sentiment_ml": None,
                 "return_1d": None,
                 "return_3d": None,

--- a/wallenstein/reddit_enrich.py
+++ b/wallenstein/reddit_enrich.py
@@ -291,10 +291,11 @@ def compute_reddit_sentiment(
             DATE_TRUNC('hour', created_utc) AS created_utc,
             ticker,
             AVG(sentiment_dict) AS sentiment_dict,
-            SUM(sentiment_weighted) / NULLIF(SUM(1 + LOG10(1 + upvotes)), 0) AS sentiment_weighted,
+            SUM(sentiment_dict * (1 + LOG10(1 + upvotes)))
+                / NULLIF(SUM(1 + LOG10(1 + upvotes)), 0) AS sentiment_weighted,
             COUNT(*) AS posts
         FROM reddit_enriched
-        WHERE sentiment_weighted IS NOT NULL {hour_filter}
+        WHERE sentiment_dict IS NOT NULL {hour_filter}
         GROUP BY 1, 2
         """,
     )
@@ -306,10 +307,11 @@ def compute_reddit_sentiment(
             DATE_TRUNC('day', created_utc) AS date,
             ticker,
             AVG(sentiment_dict) AS sentiment_dict,
-            SUM(sentiment_weighted) / NULLIF(SUM(1 + LOG10(1 + upvotes)), 0) AS sentiment_weighted,
+            SUM(sentiment_dict * (1 + LOG10(1 + upvotes)))
+                / NULLIF(SUM(1 + LOG10(1 + upvotes)), 0) AS sentiment_weighted,
             COUNT(*) AS posts
         FROM reddit_enriched
-        WHERE sentiment_weighted IS NOT NULL {day_filter}
+        WHERE sentiment_dict IS NOT NULL {day_filter}
         GROUP BY 1, 2
         """,
     )


### PR DESCRIPTION
## Summary
- recompute weighted sentiment during hourly and daily aggregation
- ensure tests cover legacy rows with old log1p weighting

## Testing
- `ruff check wallenstein/reddit_enrich.py tests/test_reddit_enrich.py`
- `pytest tests/test_reddit_enrich.py tests/test_overview.py tests/test_telegram_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68b86698149483258682b01bfb86cff3