### PR TITLE
Handle weighted zip without Python 3.10 strict

### DIFF
--- a/wallenstein/trending.py
+++ b/wallenstein/trending.py
@@ -96,7 +96,10 @@ def _count_weighted_mentions(df: pd.DataFrame, patmap: Dict[str, list[re.Pattern
     com_series = df.get("num_comments", 0)
     com = pd.to_numeric(com_series, errors="coerce").fillna(0).astype(float)
     weights = 1.0 + ups.add(1).apply(math.log10) + 0.2 * com.add(1).apply(math.log10)
-    for txt, w in zip(df["text"].astype(str), weights, strict=False):
+    texts = df["text"].astype(str)
+    if len(texts) != len(weights):
+        raise ValueError("Length mismatch between texts and weights")
+    for txt, w in zip(texts, weights):  # noqa: B905
         for s in _match_with_patterns(txt, patmap):
             counts[s] = counts.get(s, 0.0) + float(w)
     return counts


### PR DESCRIPTION
## Summary
- Avoid `zip(..., strict=False)` in weighted mention counting for pre-3.10 compatibility
- Manually check text and weight lengths before zipping

## Testing
- `ruff check wallenstein/trending.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'wallenstein')*


------
https://chatgpt.com/codex/tasks/task_e_68b87181dde88325a2babf0e63ac4437