### PR TITLE
Use sqlparse for safer SQL script execution

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 pandas
 yfinance
 duckdb
+sqlparse
 requests
 python-dotenv
 praw

--- a/wallenstein/db.py
+++ b/wallenstein/db.py
@@ -13,6 +13,7 @@ from importlib import resources
 from pathlib import Path
 
 import duckdb
+import sqlparse
 
 from .config import settings
 from .db_schema import ensure_tables
@@ -31,7 +32,7 @@ def get_connection(db_path: str | None = None) -> duckdb.DuckDBPyConnection:
 
 def _execute_script(con: duckdb.DuckDBPyConnection, script: str) -> None:
     """Execute a multi-statement SQL script."""
-    for statement in script.split(";"):
+    for statement in sqlparse.split(script):
         stmt = statement.strip()
         if stmt:
             con.execute(stmt)


### PR DESCRIPTION
## Summary
- replace ad-hoc semicolon splitting with `sqlparse.split` when running SQL scripts
- include `sqlparse` as a dependency

## Testing
- `ruff check wallenstein/db.py`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b87184001083259a86b37738f1bf29