### PR TITLE
Add NLTK dependency and document VADER lexicon download

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Broker-target support is temporarily disabled pending a new data provider.
 ## Quickstart
 ```bash
 pip install -r requirements.txt
-python -c "import nltk; nltk.download('vader_lexicon')"  # pre-install VADER lexicon
+# The VADER lexicon downloads automatically on first run; pre-download it for
+# offline use with the following command (optional):
+python -m nltk.downloader vader_lexicon
 cp .env.example .env   # and fill values
 python main.py
 python -m bot.telegram_bot  # optional: manage watchlist via Telegram
@@ -131,7 +133,7 @@ is available the engine uses the multilingual
 for negative, neutral and positive labels. If `transformers` or its
 dependencies are missing, the system falls back to NLTK's VADER lexicon. The
 lexicon downloads automatically when online; to prepare an offline environment
-run `python -c "import nltk; nltk.download('vader_lexicon')"` ahead of time.
+run `python -m nltk.downloader vader_lexicon` ahead of time.
 
 Simple keyword boosts adjust the score (`+0.2` for "long"/"call", `-0.2` for
 "short"/"put" with a cap of ±0.4). Each post receives a weight of

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ scikit-learn
 pyyaml
 imbalanced-learn>=0.12
 langdetect>=1.0.9
+nltk
 transformers>=4.41
 optuna
 optuna-integration[sklearn]


### PR DESCRIPTION
## Summary
- Add NLTK to project dependencies
- Explain automatic VADER lexicon download and include manual `nltk.downloader` command

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'wallenstein')*

------
https://chatgpt.com/codex/tasks/task_e_68b8718f701883259cc9c9c73bbb3d0e