### PR TITLE
Use Reddit comment counts in trending analysis

### DIFF
--- a/wallenstein/trending.py
+++ b/wallenstein/trending.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import math
 import re
 from dataclasses import dataclass
-from typing import Dict, List, Set
 
 import duckdb
 import pandas as pd
@@ -20,9 +19,11 @@ class TrendCandidate:
     lift: float
     trend: float  # lift * log1p(mentions)
 
+
 # ---------- Tabellen ----------
 def ensure_trending_tables(con: duckdb.DuckDBPyConnection) -> None:
-    con.execute("""
+    con.execute(
+        """
     CREATE TABLE IF NOT EXISTS trending_candidates (
         symbol VARCHAR PRIMARY KEY,
         mentions_24h INTEGER,
@@ -31,8 +32,10 @@ def ensure_trending_tables(con: duckdb.DuckDBPyConnection) -> None:
         trend DOUBLE,
         first_seen TIMESTAMP,
         last_seen TIMESTAMP
-    )""")
-    con.execute("""
+    )"""
+    )
+    con.execute(
+        """
     CREATE TABLE IF NOT EXISTS trending_candidates_history (
         ts TIMESTAMP,
         symbol VARCHAR,
@@ -40,16 +43,18 @@ def ensure_trending_tables(con: duckdb.DuckDBPyConnection) -> None:
         baseline_rate_per_h DOUBLE,
         lift DOUBLE,
         trend DOUBLE
-    )""")
+    )"""
+    )
+
 
 # ---------- Regex-Matching vorbereiten ----------
-def _compile_alias_patterns(amap: Dict[str, Set[str]]) -> Dict[str, list[re.Pattern]]:
+def _compile_alias_patterns(amap: dict[str, set[str]]) -> dict[str, list[re.Pattern]]:
     """
     Erzeugt pro Symbol eine Liste Regex-Pattern:
       - Wortgrenzen für Plain-Words
       - Cashtag (#, $) Varianten
     """
-    patmap: Dict[str, list[re.Pattern]] = {}
+    patmap: dict[str, list[re.Pattern]] = {}
     for sym, aliases in amap.items():
         pats: list[re.Pattern] = []
         seen: set[str] = set()
@@ -68,10 +73,11 @@ def _compile_alias_patterns(amap: Dict[str, Set[str]]) -> Dict[str, list[re.Patt
         patmap[sym] = pats
     return patmap
 
-def _match_with_patterns(text: str, patmap: Dict[str, list[re.Pattern]]) -> Set[str]:
+
+def _match_with_patterns(text: str, patmap: dict[str, list[re.Pattern]]) -> set[str]:
     if not text:
         return set()
-    hits: Set[str] = set()
+    hits: set[str] = set()
     for sym, pats in patmap.items():
         for p in pats:
             if p.search(text):
@@ -80,17 +86,22 @@ def _match_with_patterns(text: str, patmap: Dict[str, list[re.Pattern]]) -> Set[
     # Konflikte bei Überschneidungen (optional: längster Alias gewinnt)
     return hits
 
+
 # ---------- Zählen ----------
-def _count_mentions(df: pd.DataFrame, patmap: Dict[str, list[re.Pattern]]) -> Dict[str, int]:
-    counts: Dict[str, int] = {}
+def _count_mentions(df: pd.DataFrame, patmap: dict[str, list[re.Pattern]]) -> dict[str, int]:
+    counts: dict[str, int] = {}
     for txt in df["text"].astype(str):
         for s in _match_with_patterns(txt, patmap):
             counts[s] = counts.get(s, 0) + 1
     return counts
 
+
 # Optional: gewichtete Zählung (Upvotes/Kommentare)
-def _count_weighted_mentions(df: pd.DataFrame, patmap: Dict[str, list[re.Pattern]]) -> Dict[str, float]:
-    counts: Dict[str, float] = {}
+def _count_weighted_mentions(
+    df: pd.DataFrame, patmap: dict[str, list[re.Pattern]]
+) -> dict[str, float]:
+    """Count mentions weighted by upvotes and comment volume."""
+    counts: dict[str, float] = {}
     ups_series = df.get("ups", df.get("upvotes", 0))
     ups = pd.to_numeric(ups_series, errors="coerce").fillna(0).astype(float)
     com_series = df.get("num_comments", 0)
@@ -104,6 +115,7 @@ def _count_weighted_mentions(df: pd.DataFrame, patmap: Dict[str, list[re.Pattern
             counts[s] = counts.get(s, 0.0) + float(w)
     return counts
 
+
 # ---------- Hauptscan ----------
 def scan_reddit_for_candidates(
     con: duckdb.DuckDBPyConnection,
@@ -111,9 +123,9 @@ def scan_reddit_for_candidates(
     window_hours: int = 24,
     min_mentions: int = 20,
     min_lift: float = 3.0,
-    k_smooth: float = 0.5,          # Laplace-Glättung
-    use_weighted: bool = False,     # Upvotes/Kommentare gewichten?
-) -> List[TrendCandidate]:
+    k_smooth: float = 0.5,  # Laplace-Glättung
+    use_weighted: bool = False,  # Upvotes/Kommentare gewichten?
+) -> list[TrendCandidate]:
     """
     Liefert sortierte Trendkandidaten (trend desc).
     Baseline = base_mentions / base_hours (geglättet). Lift = mentions24 / max(baseline*24, eps).
@@ -127,40 +139,51 @@ def scan_reddit_for_candidates(
     patmap = _compile_alias_patterns(amap)
 
     # Fenster laden (UTC im DB; hier neutral belassen)
-    # Kommentarzahlen sind derzeit nicht verfügbar
-    # TODO: Falls num_comments verfügbar ist, Abfrage erweitern
-    df_win = con.execute(f"""
-        SELECT created_utc, text, upvotes AS ups, 0 AS num_comments
+    cols = {row[1] for row in con.execute("PRAGMA table_info('reddit_posts')").fetchall()}
+    num_comments_expr = "num_comments" if "num_comments" in cols else "0 AS num_comments"
+    df_win = con.execute(
+        f"""
+        SELECT created_utc, text, upvotes AS ups, {num_comments_expr}
         FROM reddit_posts
         WHERE created_utc >= NOW() - INTERVAL {int(window_hours)} HOUR
-    """).fetchdf()
+    """
+    ).fetchdf()
 
     if df_win.empty:
         return []
 
-    df_base = con.execute(f"""
-        SELECT created_utc, text, upvotes AS ups, 0 AS num_comments
+    df_base = con.execute(
+        f"""
+        SELECT created_utc, text, upvotes AS ups, {num_comments_expr}
         FROM reddit_posts
         WHERE created_utc >= NOW() - INTERVAL {int(lookback_days*24)} HOUR
           AND created_utc <  NOW() - INTERVAL {int(window_hours)} HOUR
-    """).fetchdf()
+    """
+    ).fetchdf()
 
     # Zählen
-    win_counts_raw = _count_weighted_mentions(df_win, patmap) if use_weighted else _count_mentions(df_win, patmap)
-    base_counts_raw = (_count_weighted_mentions(df_base, patmap) if (use_weighted and not df_base.empty)
-                       else (_count_mentions(df_base, patmap) if not df_base.empty else {}))
+    win_counts_raw = (
+        _count_weighted_mentions(df_win, patmap)
+        if use_weighted
+        else _count_mentions(df_win, patmap)
+    )
+    base_counts_raw = (
+        _count_weighted_mentions(df_base, patmap)
+        if (use_weighted and not df_base.empty)
+        else (_count_mentions(df_base, patmap) if not df_base.empty else {})
+    )
 
     # Stunden
     base_hours = max(1.0, float(lookback_days * 24 - window_hours))
     # Baseline-Rate/h + Glättung
-    baseline_rate_per_h: Dict[str, float] = {}
+    baseline_rate_per_h: dict[str, float] = {}
     for s in amap.keys():
         base_val = float(base_counts_raw.get(s, 0.0))
         # Laplace: +k in Zähler und Nenner
         baseline_rate_per_h[s] = (base_val + k_smooth) / (base_hours + k_smooth)
 
     # Kandidaten bauen
-    candidates: List[TrendCandidate] = []
+    candidates: list[TrendCandidate] = []
     for s, cnt in win_counts_raw.items():
         mentions = int(round(cnt)) if use_weighted else int(cnt)
         if mentions < min_mentions:
@@ -176,19 +199,32 @@ def scan_reddit_for_candidates(
     # Persistenz
     now = con.execute("SELECT NOW()").fetchone()[0]
     if candidates:
-        data = [(now, c.symbol, c.mentions_24h, c.baseline_rate_per_h, c.lift, c.trend) for c in candidates]
-        con.executemany("""
+        data = [
+            (now, c.symbol, c.mentions_24h, c.baseline_rate_per_h, c.lift, c.trend)
+            for c in candidates
+        ]
+        con.executemany(
+            """
             INSERT INTO trending_candidates_history (ts, symbol, mentions_24h, baseline_rate_per_h, lift, trend)
             VALUES (?, ?, ?, ?, ?, ?)
-        """, data)
+        """,
+            data,
+        )
 
         # "latest" Tabelle aktualisieren (DuckDB: MERGE verfügbar; sonst DELETE+INSERT)
         try:
-            con.register("tmp_trends", pd.DataFrame(
-                [(c.symbol, c.mentions_24h, c.baseline_rate_per_h, c.lift, c.trend) for c in candidates],
-                columns=["symbol","mentions_24h","baseline_rate_per_h","lift","trend"]
-            ))
-            con.execute("""
+            con.register(
+                "tmp_trends",
+                pd.DataFrame(
+                    [
+                        (c.symbol, c.mentions_24h, c.baseline_rate_per_h, c.lift, c.trend)
+                        for c in candidates
+                    ],
+                    columns=["symbol", "mentions_24h", "baseline_rate_per_h", "lift", "trend"],
+                ),
+            )
+            con.execute(
+                """
                 MERGE INTO trending_candidates t
                 USING tmp_trends s
                 ON t.symbol = s.symbol
@@ -201,18 +237,28 @@ def scan_reddit_for_candidates(
                 WHEN NOT MATCHED THEN INSERT
                     (symbol, mentions_24h, baseline_rate_per_h, lift, trend, first_seen, last_seen)
                 VALUES (s.symbol, s.mentions_24h, s.baseline_rate_per_h, s.lift, s.trend, NOW(), NOW())
-            """)
+            """
+            )
         except Exception:
             # Fallback: DELETE+INSERT (kompatibel mit älteren DuckDBs)
             symbols = [c.symbol for c in candidates]
-            con.executemany("DELETE FROM trending_candidates WHERE symbol = ?", [(s,) for s in symbols])
-            con.executemany("""
+            con.executemany(
+                "DELETE FROM trending_candidates WHERE symbol = ?", [(s,) for s in symbols]
+            )
+            con.executemany(
+                """
                 INSERT INTO trending_candidates(symbol, mentions_24h, baseline_rate_per_h, lift, trend, first_seen, last_seen)
                 VALUES (?, ?, ?, ?, ?, NOW(), NOW())
-            """, [(c.symbol, c.mentions_24h, c.baseline_rate_per_h, c.lift, c.trend) for c in candidates])
+            """,
+                [
+                    (c.symbol, c.mentions_24h, c.baseline_rate_per_h, c.lift, c.trend)
+                    for c in candidates
+                ],
+            )
 
     # Sortierung: erst trend, dann lift, dann mentions
     return sorted(candidates, key=lambda x: (x.trend, x.lift, x.mentions_24h), reverse=True)
+
 
 # ---------- Watchlist ----------
 def auto_add_candidates_to_watchlist(
@@ -221,19 +267,21 @@ def auto_add_candidates_to_watchlist(
     max_new: int = 3,
     min_mentions: int = 30,
     min_lift: float = 4.0,
-) -> List[str]:
+) -> list[str]:
     ensure_trending_tables(con)
-    rows = con.execute("""
+    rows = con.execute(
+        """
         SELECT symbol, mentions_24h, baseline_rate_per_h, lift, trend
         FROM trending_candidates
         ORDER BY trend DESC, lift DESC, mentions_24h DESC
         LIMIT 20
-    """).fetchall()
+    """
+    ).fetchall()
     if not rows:
         return []
 
-    wl = set(s for (s,) in con.execute("SELECT DISTINCT symbol FROM watchlist").fetchall())
-    added: List[str] = []
+    wl = {s for (s,) in con.execute("SELECT DISTINCT symbol FROM watchlist").fetchall()}
+    added: list[str] = []
     for sym, mentions, _base_rate, lift, trend in rows:
         if len(added) >= max_new:
             break


### PR DESCRIPTION
## Summary
- include `num_comments` from `reddit_posts` when present
- weight mentions by both upvotes and comment volume

## Testing
- `pre-commit run --files wallenstein/trending.py`
- `python -m pytest tests/test_trending.py`


------
https://chatgpt.com/codex/tasks/task_e_68b87aefb5fc8325912f1e3f810e9bb5