### PR TITLE
Use index-based offsets for forward returns

### DIFF
--- a/tests/test_reddit_enrich.py
+++ b/tests/test_reddit_enrich.py
@@ -172,8 +172,8 @@ def test_compute_returns():
     ).fetchone()
 
     assert row[0] == pytest.approx(0.1)
-    assert row[1] == pytest.approx(0.4)
-    assert row[2] == pytest.approx(1.0)
+    assert row[1] == pytest.approx(1.0)
+    assert row[2] is None
 
 
 def test_compute_reddit_sentiment():

--- a/wallenstein/reddit_enrich.py
+++ b/wallenstein/reddit_enrich.py
@@ -212,8 +212,8 @@ def compute_returns(
 
             ret_vals: list[float | None] = []
             for h in horizon_days:
-                target = r.created_utc + pd.Timedelta(days=h)
-                idxN = grp["date"].searchsorted(target, side="left")
+                # Index-basiert: h Handelstage nach dem Basisdatum
+                idxN = idx0 + h
                 if idxN >= len(grp):
                     ret_vals.append(None)
                 else:
@@ -324,6 +324,7 @@ def compute_reddit_sentiment(
     ).fetchone()[0]
 
     return int(rows_hourly or 0), int(rows_daily or 0)
+
 
 __all__ = [
     "enrich_reddit_posts",


### PR DESCRIPTION
## Summary
- compute Reddit forward returns using trading-day index offsets instead of calendar-date lookups
- adjust tests for updated return computation semantics

## Testing
- `python -m pre_commit run --files wallenstein/reddit_enrich.py tests/test_reddit_enrich.py`
- `pytest tests/test_reddit_enrich.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'wallenstein')*


------
https://chatgpt.com/codex/tasks/task_e_68b87aedac988325afeae208114f7cfb