### PR TITLE
feat: add optional Hugging Face hub login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,4 @@ GOOGLE_API_KEYFILE=Google_API.json
 DB_PATH=stock_data.duckdb
 FINNHUB_TOKEN="your_finhub_token_here"
 PIPELINE_MAX_WORKERS=4
+HUGGING_FACE_HUB_TOKEN=your_hf_token_here

--- a/.github/workflows/run_script.yml
+++ b/.github/workflows/run_script.yml
@@ -30,6 +30,9 @@ jobs:
       REDDIT_CLIENT_SECRET: ${{ secrets.REDDIT_CLIENT_SECRET }}
       REDDIT_USER_AGENT:    ${{ secrets.REDDIT_USER_AGENT }}
 
+      # HuggingFace
+      HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/wallenstein/config.py
+++ b/wallenstein/config.py
@@ -50,6 +50,9 @@ class Settings:
     REDDIT_CLIENT_SECRET = _get("REDDIT_CLIENT_SECRET", "CLIENT_SECRET")
     REDDIT_USER_AGENT = _get("REDDIT_USER_AGENT", "USER_AGENT")
 
+    # HuggingFace Hub
+    HUGGING_FACE_HUB_TOKEN = _get("HUGGING_FACE_HUB_TOKEN", "HF_TOKEN")
+
     USE_BERT_SENTIMENT = _as_bool(_get("USE_BERT_SENTIMENT"), default=False)
     LOG_LEVEL = _get("LOG_LEVEL") or "INFO"
     REQUEST_TIMEOUT = int(_get("REQUEST_TIMEOUT") or "15")


### PR DESCRIPTION
## Summary
- load optional HUGGING_FACE_HUB_TOKEN from env
- authenticate with Hugging Face Hub in sentiment modules when token provided
- allow CI to pass Hugging Face token

## Testing
- `pre-commit run --files .env.example wallenstein/config.py wallenstein/sentiment.py wallenstein/sentiment_analysis.py .github/workflows/run_script.yml`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b886b601c48325962ec2469c6a942f