### PR TITLE
feat: add tickers to workflow env

### DIFF
--- a/.github/workflows/run_script.yml
+++ b/.github/workflows/run_script.yml
@@ -32,6 +32,7 @@ jobs:
 
       # HuggingFace
       HUGGINGFACE_HUB_TOKEN: ${{ secrets.HUGGINGFACE_HUB_TOKEN }}
+      WALLENSTEIN_TICKERS: NVDA,AMZN,SMCI,TSLA
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- define `WALLENSTEIN_TICKERS` in the CI run job so the pipeline handles NVDA, AMZN, SMCI, TSLA

## Testing
- `PYTHONPATH=$PWD pytest -q` *(fails: AttributeError: module 'wallenstein.sentiment' has no attribute 'BertSentiment')*


------
https://chatgpt.com/codex/tasks/task_e_68b9e583e43c8325ab673152efb29b4e