### PR TITLE
feat: add env ticker config and merge with watchlist

### DIFF
--- a/.github/workflows/run_script.yml
+++ b/.github/workflows/run_script.yml
@@ -32,6 +32,7 @@ jobs:
 
       # HuggingFace
       HUGGINGFACE_HUB_TOKEN: ${{ secrets.HUGGINGFACE_HUB_TOKEN }}
+      WALLENSTEIN_TICKERS: NVDA,AMZN,SMCI,TSLA
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- define `WALLENSTEIN_TICKERS` in the CI run job so the pipeline handles NVDA, AMZN, SMCI, TSLA
- merge `WALLENSTEIN_TICKERS` with the DuckDB watchlist so Telegram-managed symbols are also processed

## Testing
- `ruff check main.py`
- `PYTHONPATH=$PWD pytest -q` *(fails: AttributeError: module 'wallenstein.sentiment' has no attribute 'BertSentiment')*


------
https://chatgpt.com/codex/tasks/task_e_68b9e583e43c8325ab673152efb29b4e