### PR TITLE
ci: persist watchlist db

### DIFF
--- a/.github/workflows/run_script.yml
+++ b/.github/workflows/run_script.yml
@@ -32,7 +32,6 @@ jobs:
 
       # HuggingFace
       HUGGINGFACE_HUB_TOKEN: ${{ secrets.HUGGINGFACE_HUB_TOKEN }}
-      WALLENSTEIN_TICKERS: NVDA,AMZN,SMCI,TSLA
 
     steps:
       - name: Checkout
@@ -54,6 +53,13 @@ jobs:
 
       - name: Prepare folders
         run: mkdir -p data stockOverview
+
+      - name: Restore previous DuckDB (optional)
+        uses: actions/download-artifact@v4
+        with:
+          name: duckdb
+          path: data
+        continue-on-error: true
 
       # Falls versehentlich eine .env im Repo liegt: nicht die Secrets überschreiben lassen
       - name: Neutralize local .env on CI
@@ -142,11 +148,11 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
 
-      - name: Persist DuckDB optional
+      - name: Persist DuckDB
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: duckdb-${{ github.run_id }}
+          name: duckdb
           path: data/*.duckdb
           if-no-files-found: warn
           retention-days: 3


### PR DESCRIPTION
## Summary
- download previous DuckDB artifact so workflow reads watchlist symbols
- persist DuckDB under stable name and drop hardcoded ticker list

## Testing
- `pre-commit run --files .github/workflows/run_script.yml`
- `PYTHONPATH=. pytest` *(fails: AttributeError: wallenstein.sentiment has no attribute 'BertSentiment')*

------
https://chatgpt.com/codex/tasks/task_e_68ba98d0f604832591d1a1eb189fbc47