### PR TITLE
ci: restore default tickers env

### DIFF
--- a/.github/workflows/run_script.yml
+++ b/.github/workflows/run_script.yml
@@ -33,6 +33,9 @@ jobs:
       # HuggingFace
       HUGGINGFACE_HUB_TOKEN: ${{ secrets.HUGGINGFACE_HUB_TOKEN }}
 
+      # Default tickers for initial runs
+      WALLENSTEIN_TICKERS: "NVDA,AMZN,SMCI,TSLA"
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- ensure initial runs process default tickers by exporting `WALLENSTEIN_TICKERS` in CI workflow

## Testing
- `pre-commit run --files .github/workflows/run_script.yml`
- `PYTHONPATH=. pytest` *(fails: AttributeError: wallenstein.sentiment has no attribute 'BertSentiment'; AssertionError in FinBERT adapter)*

------
https://chatgpt.com/codex/tasks/task_e_68babd4011348325bcafed81b444bdd8