### PR TITLE
feat: telegram trending and dynamic aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ list of additional names that should be recognised in Reddit posts:
 `reddit_scraper` loads this file on startup and merges it with its built-in
 defaults. If the file is missing, the internal map is used unchanged.
 
+Aliases are automatically expanded with simple [WordNet](https://wordnet.princeton.edu/) synonyms
+when available, so "car" would also match posts mentioning "auto" or "automobile".
+
 Aliases can also be supplied dynamically when calling
 ``update_reddit_data``. Pass either a path to a JSON/YAML file via
 ``aliases_path`` or an in-memory mapping via ``aliases``:

--- a/main.py
+++ b/main.py
@@ -320,6 +320,7 @@ def generate_trends(reddit_posts: dict[str, list]) -> None:
                     [f"{c.symbol} (m24h={c.mentions_24h}, x{c.lift:.1f})" for c in cands[:5]]
                 )
                 log.info(f"Trending-Kandidaten (Top 5): {top_preview}")
+                notify_telegram("🔥 Reddit-Trends: " + top_preview)
             else:
                 log.info("Trending-Kandidaten: keine")
             added_syms = auto_add_candidates_to_watchlist(

--- a/tests/test_aliases_synonyms.py
+++ b/tests/test_aliases_synonyms.py
@@ -1,0 +1,23 @@
+import pytest
+import duckdb
+
+from wallenstein.aliases import add_alias, alias_map
+
+
+def _wordnet_available() -> bool:
+    try:
+        from nltk.corpus import wordnet  # type: ignore
+
+        wordnet.synsets("car")
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _wordnet_available(), reason="WordNet not available")
+def test_alias_map_expands_synonyms(tmp_path):
+    con = duckdb.connect(database=":memory:")
+    add_alias(con, "AAA", "car")
+    amap = alias_map(con, use_synonyms=True)
+    assert "AAA" in amap
+    assert any(syn in amap["AAA"] for syn in {"auto", "automobile"})

--- a/wallenstein/aliases.py
+++ b/wallenstein/aliases.py
@@ -1,13 +1,21 @@
 from __future__ import annotations
+
 import json
 from pathlib import Path
-from typing import Dict, List, Set
+
 import duckdb
+
+try:
+    from nltk.corpus import wordnet as wn  # type: ignore
+except Exception:  # pragma: no cover - fallback when nltk/wordnet missing
+    wn = None  # type: ignore
 
 DATA_FILE = Path(__file__).resolve().parents[1] / "data" / "ticker_aliases.json"
 
+
 def ensure_table(con: duckdb.DuckDBPyConnection) -> None:
-    con.execute("""
+    con.execute(
+        """
         CREATE TABLE IF NOT EXISTS ticker_aliases (
           ticker VARCHAR,
           alias  VARCHAR,
@@ -15,7 +23,9 @@ def ensure_table(con: duckdb.DuckDBPyConnection) -> None:
           added_at TIMESTAMP DEFAULT NOW(),
           UNIQUE(ticker, alias)
         )
-    """)
+    """
+    )
+
 
 def seed_from_json(con: duckdb.DuckDBPyConnection) -> int:
     ensure_table(con)
@@ -39,37 +49,74 @@ def seed_from_json(con: duckdb.DuckDBPyConnection) -> int:
     post_count = con.execute("SELECT COUNT(*) FROM ticker_aliases").fetchone()[0]
     return post_count - pre_count
 
+
 def add_alias(con: duckdb.DuckDBPyConnection, ticker: str, alias: str, source="manual") -> bool:
     ensure_table(con)
     t, a = ticker.upper().strip(), alias.strip()
     if not t or not a:
         return False
-    con.execute("INSERT OR IGNORE INTO ticker_aliases (ticker, alias, source) VALUES (?, ?, ?)", [t, a, source])
+    con.execute(
+        "INSERT OR IGNORE INTO ticker_aliases (ticker, alias, source) VALUES (?, ?, ?)",
+        [t, a, source],
+    )
     return True
+
 
 def remove_alias(con: duckdb.DuckDBPyConnection, ticker: str, alias: str) -> int:
     ensure_table(con)
-    return con.execute("DELETE FROM ticker_aliases WHERE ticker = ? AND alias = ?", [ticker.upper().strip(), alias.strip()]).rowcount
+    return con.execute(
+        "DELETE FROM ticker_aliases WHERE ticker = ? AND alias = ?",
+        [ticker.upper().strip(), alias.strip()],
+    ).rowcount
 
-def list_aliases(con: duckdb.DuckDBPyConnection, ticker: str | None = None) -> Dict[str, List[str]]:
+
+def list_aliases(con: duckdb.DuckDBPyConnection, ticker: str | None = None) -> dict[str, list[str]]:
     ensure_table(con)
     if ticker:
-        rows = con.execute("SELECT ticker, alias FROM ticker_aliases WHERE ticker = ? ORDER BY alias", [ticker.upper().strip()]).fetchall()
+        rows = con.execute(
+            "SELECT ticker, alias FROM ticker_aliases WHERE ticker = ? ORDER BY alias",
+            [ticker.upper().strip()],
+        ).fetchall()
     else:
-        rows = con.execute("SELECT ticker, alias FROM ticker_aliases ORDER BY ticker, alias").fetchall()
-    out: Dict[str, List[str]] = {}
+        rows = con.execute(
+            "SELECT ticker, alias FROM ticker_aliases ORDER BY ticker, alias"
+        ).fetchall()
+    out: dict[str, list[str]] = {}
     for t, a in rows:
         out.setdefault(t, []).append(a)
     return out
 
-def alias_map(con: duckdb.DuckDBPyConnection, include_ticker_itself: bool = True) -> Dict[str, Set[str]]:
+
+def _synonym_variants(word: str) -> set[str]:
+    """Return a set of simple synonyms for ``word`` via WordNet."""
+    if wn is None:
+        return set()
+    try:
+        syns: set[str] = set()
+        for syn in wn.synsets(word):
+            for lemma in syn.lemmas():
+                name = lemma.name().replace("_", " ")
+                if name.lower() != word.lower():
+                    syns.add(name)
+        return syns
+    except Exception:  # pragma: no cover - wordnet not downloaded
+        return set()
+
+
+def alias_map(
+    con: duckdb.DuckDBPyConnection,
+    include_ticker_itself: bool = True,
+    use_synonyms: bool = False,
+) -> dict[str, set[str]]:
     ensure_table(con)
     rows = con.execute("SELECT ticker, alias FROM ticker_aliases").fetchall()
-    m: Dict[str, Set[str]] = {}
+    m: dict[str, set[str]] = {}
     for t, a in rows:
         s = m.setdefault(t, set())
         if a:
             s.add(a)
+            if use_synonyms:
+                s.update(_synonym_variants(a))
         if include_ticker_itself:
             s.add(t)
             s.add(f"${t}")

--- a/wallenstein/trending.py
+++ b/wallenstein/trending.py
@@ -132,7 +132,8 @@ def scan_reddit_for_candidates(
     trend = lift * log1p(mentions24)
     """
     ensure_trending_tables(con)
-    amap = alias_map(con, include_ticker_itself=True)
+    # include basic aliases plus WordNet synonyms for broader matching
+    amap = alias_map(con, include_ticker_itself=True, use_synonyms=True)
     if not amap:
         return []
 


### PR DESCRIPTION
## Summary
- expand ticker alias mapping with WordNet synonyms
- notify Telegram about top Reddit trending tickers
- add regression test for dynamic alias expansion

## Testing
- `pre-commit run --files wallenstein/aliases.py wallenstein/trending.py main.py tests/test_aliases_synonyms.py README.md`
- `PYTHONPATH=. pytest tests/test_aliases_synonyms.py tests/test_trending.py tests/test_notify.py tests/test_reddit_enrich.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2d8500e0c8325b2b870666ccafdef