### PR TITLE
Expand ticker aliases and refine sentiment analyzer

### DIFF
--- a/data/ticker_aliases.json
+++ b/data/ticker_aliases.json
@@ -6,7 +6,8 @@
     "GOOG": ["google", "alphabet", "googel", "gogle"],
     "META": ["facebook", "meta", "metta", "facebok"],
     "TSLA": ["tesla", "tesler", "tesal"],
-    "RHM": ["rheinmetall", "rheiner"],
+    "RHM": ["rheinmetall", "rheiner", "rheinmetal", "rhm.de"],
     "GME": ["gamestop", "game stop", "gme"],
-    "BABA": ["alibaba", "ali baba", "alibba"]
+    "BABA": ["alibaba", "ali baba", "alibba"],
+    "OPEN": ["opendoor", "opendoor technologies", "opendoor tech"]
 }

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -1,5 +1,11 @@
 import duckdb
 import pytest
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 from wallenstein import alerts
 

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -50,3 +50,24 @@ def test_generate_overview_includes_latest_sentiment(monkeypatch, tmp_path):
 
     result = generate_overview(['NVDA'], reddit_posts={'NVDA': []})
     assert 'Sentiment (1d, weighted): +0.50' in result
+
+
+def test_generate_overview_lists_aliases(monkeypatch, tmp_path):
+    db_path = tmp_path / 'db.duckdb'
+    con = duckdb.connect(str(db_path))
+    con.execute(
+        "CREATE TABLE ticker_aliases (ticker VARCHAR, alias VARCHAR, source VARCHAR)"
+    )
+    con.execute(
+        "INSERT INTO ticker_aliases VALUES ('NVDA', 'nvidia', 'seed')"
+    )
+    con.close()
+
+    monkeypatch.setattr(
+        'wallenstein.overview.get_latest_prices',
+        lambda db_path, tickers, use_eur=False: {t: 1.0 for t in tickers},
+    )
+    monkeypatch.setattr('wallenstein.overview.DB_PATH', str(db_path))
+
+    result = generate_overview(['NVDA'], reddit_posts={'NVDA': []})
+    assert 'Alias: nvidia' in result

--- a/tests/test_reddit_scraper.py
+++ b/tests/test_reddit_scraper.py
@@ -25,6 +25,8 @@ def test_company_name_bucketed(monkeypatch):
         {"id": "3", "title": "", "created_utc": now, "text": "Rheiner secures big contract"},
         {"id": "4", "title": "", "created_utc": now, "text": "Game stop hype again"},
         {"id": "5", "title": "", "created_utc": now, "text": "Ali babA expands"},
+        {"id": "6", "title": "", "created_utc": now, "text": "Rheinmetal reports record order"},
+        {"id": "7", "title": "", "created_utc": now, "text": "Opendoor Technologies enters new market"},
     ])
 
     def fake_fetch(*args, **kwargs):
@@ -35,18 +37,22 @@ def test_company_name_bucketed(monkeypatch):
     monkeypatch.setattr(reddit_scraper, "purge_old_posts", lambda: None)
 
     out = reddit_scraper.update_reddit_data(
-        ["NVDA", "AMZN", "RHM", "GME", "BABA"], subreddits=None
+        ["NVDA", "AMZN", "RHM", "GME", "BABA", "OPEN"], subreddits=None
     )
     assert len(out["NVDA"]) == 1
     assert len(out["AMZN"]) == 1
-    assert len(out["RHM"]) == 1
+    assert len(out["RHM"]) == 2
     assert len(out["GME"]) == 1
     assert len(out["BABA"]) == 1
+    assert len(out["OPEN"]) == 1
+    texts_rhm = " ".join(p["text"].lower() for p in out["RHM"])
+    assert "rheiner" in texts_rhm
+    assert "rheinmetal" in texts_rhm
     assert "nividia" in out["NVDA"][0]["text"].lower()
     assert "amzon" in out["AMZN"][0]["text"].lower()
-    assert "rheiner" in out["RHM"][0]["text"].lower()
     assert "game stop" in out["GME"][0]["text"].lower()
     assert "ali baba" in out["BABA"][0]["text"].lower()
+    assert "opendoor" in out["OPEN"][0]["text"].lower()
 
 
 def test_aliases_loaded_from_file():

--- a/wallenstein/overview.py
+++ b/wallenstein/overview.py
@@ -79,6 +79,16 @@ def generate_overview(
             usd = prices_usd.get(t)
             eur = prices_eur.get(t)
             lines.append(f"📈 {t}")
+            try:
+                alias_rows = con.execute(
+                    "SELECT alias FROM ticker_aliases WHERE ticker = ? ORDER BY alias",
+                    [t],
+                ).fetchall()
+            except duckdb.Error:
+                alias_rows = []
+            aliases = ", ".join(a for a, in alias_rows if a)
+            if aliases:
+                lines.append(f"Alias: {aliases}")
             if usd is not None and eur is not None:
                 lines.append(f"{t}: {usd:.2f} USD ({eur:.2f} EUR)")
             elif usd is not None:


### PR DESCRIPTION
## Summary
- recognize Rheinmetall posts via additional aliases and add Opendoor ticker support
- extend Reddit scraper test data and fix alerts test import path
- introduce `BertSentiment` wrapper so FinBERT logic can be patched and toggled via `USE_BERT_SENTIMENT`
- surface configured ticker aliases in Telegram overview messages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3c2bb0114832599e9256c1f091f44