### PR TITLE
Detect new Reddit cashtags when scanning trends

### DIFF
--- a/tests/test_trending.py
+++ b/tests/test_trending.py
@@ -1,6 +1,9 @@
 from datetime import datetime, timedelta, timezone
 
+import duckdb
+
 from wallenstein.reddit_scraper import detect_trending_tickers
+from wallenstein.trending import scan_reddit_for_candidates
 
 
 def test_detect_trending_tickers():
@@ -19,3 +22,27 @@ def test_detect_trending_tickers():
     trending = detect_trending_tickers(data, window_hours=24, baseline_days=7, min_mentions=3, ratio=2.0)
     assert "AAA" in trending
     assert "BBB" not in trending
+
+
+def test_scan_reddit_for_candidates_finds_new_symbol(tmp_path):
+    db_path = tmp_path / "db.duckdb"
+    con = duckdb.connect(str(db_path))
+    con.execute(
+        "CREATE TABLE reddit_posts (id VARCHAR, created_utc TIMESTAMP, title VARCHAR, text VARCHAR, upvotes INTEGER)"
+    )
+    now = datetime.utcnow()
+    con.execute(
+        "INSERT INTO reddit_posts VALUES (?, ?, ?, ?, ?)",
+        ("p1", now, "🚀 $NEW to the moon", "", 42),
+    )
+
+    candidates = scan_reddit_for_candidates(
+        con,
+        lookback_days=3,
+        window_hours=24,
+        min_mentions=1,
+        min_lift=1.0,
+    )
+
+    assert any(c.symbol == "NEW" for c in candidates)
+    con.close()

--- a/wallenstein/trending.py
+++ b/wallenstein/trending.py
@@ -10,6 +10,11 @@ import pandas as pd
 from .aliases import alias_map  # liefert Dict[str, Set[str]]
 
 
+CASHTAG_PATTERN = re.compile(
+    r"(?<!\w)[\$#]([A-Z][A-Z0-9]{0,4}(?:[.\-][A-Z0-9]{1,4})?)(?![A-Za-z0-9])"
+)
+
+
 # ---------- Datenklassen ----------
 @dataclass
 class TrendCandidate:
@@ -87,6 +92,13 @@ def _match_with_patterns(text: str, patmap: dict[str, list[re.Pattern]]) -> set[
     return hits
 
 
+# ---------- Cashtag-Extraktion ----------
+def _extract_cashtags(text: str | None) -> set[str]:
+    if not text:
+        return set()
+    return {match.group(1).upper() for match in CASHTAG_PATTERN.finditer(str(text))}
+
+
 # ---------- Zählen ----------
 def _count_mentions(df: pd.DataFrame, patmap: dict[str, list[re.Pattern]]) -> dict[str, int]:
     counts: dict[str, int] = {}
@@ -133,20 +145,32 @@ def scan_reddit_for_candidates(
     """
     ensure_trending_tables(con)
     # include basic aliases plus WordNet synonyms for broader matching
-    amap = alias_map(con, include_ticker_itself=True, use_synonyms=True)
-    if not amap:
-        return []
+    base_aliases = alias_map(con, include_ticker_itself=True, use_synonyms=True)
+    amap: dict[str, set[str]] = {sym: set(names) for sym, names in base_aliases.items()}
 
-    patmap = _compile_alias_patterns(amap)
+    # Watchlist-Ticker ohne Aliase ergänzen
+    try:
+        watchlist_rows = con.execute(
+            "SELECT DISTINCT symbol FROM watchlist WHERE symbol IS NOT NULL"
+        ).fetchall()
+    except duckdb.Error:
+        watchlist_rows = []
+    for sym_raw, in watchlist_rows:
+        sym = str(sym_raw or "").strip().upper()
+        if sym:
+            amap.setdefault(sym, set()).add(sym)
 
     # Fenster laden (UTC im DB; hier neutral belassen)
     cols = {row[1] for row in con.execute("PRAGMA table_info('reddit_posts')").fetchall()}
     num_comments_expr = "num_comments" if "num_comments" in cols else "0 AS num_comments"
+    text_expr = "COALESCE(title, '') || ' ' || COALESCE(text, '') AS text"
+    window_hours_int = int(window_hours)
+    lookback_hours = int(lookback_days * 24)
     df_win = con.execute(
         f"""
-        SELECT created_utc, text, upvotes AS ups, {num_comments_expr}
+        SELECT created_utc, {text_expr}, upvotes AS ups, {num_comments_expr}
         FROM reddit_posts
-        WHERE created_utc >= NOW() - INTERVAL {int(window_hours)} HOUR
+        WHERE created_utc >= NOW() - INTERVAL {window_hours_int} HOUR
     """
     ).fetchdf()
 
@@ -155,12 +179,25 @@ def scan_reddit_for_candidates(
 
     df_base = con.execute(
         f"""
-        SELECT created_utc, text, upvotes AS ups, {num_comments_expr}
+        SELECT created_utc, {text_expr}, upvotes AS ups, {num_comments_expr}
         FROM reddit_posts
-        WHERE created_utc >= NOW() - INTERVAL {int(lookback_days*24)} HOUR
-          AND created_utc <  NOW() - INTERVAL {int(window_hours)} HOUR
+        WHERE created_utc >= NOW() - INTERVAL {lookback_hours} HOUR
+          AND created_utc <  NOW() - INTERVAL {window_hours_int} HOUR
     """
     ).fetchdf()
+
+    # Neue Cashtags aus den Texten extrahieren, um das Alias-Mapping zu erweitern
+    for df in (df_win, df_base):
+        if df.empty or "text" not in df:
+            continue
+        for text in df["text"].astype(str):
+            for tag in _extract_cashtags(text):
+                amap.setdefault(tag, set()).add(tag)
+
+    if not amap:
+        return []
+
+    patmap = _compile_alias_patterns(amap)
 
     # Zählen
     win_counts_raw = (


### PR DESCRIPTION
## Summary
- extend the Reddit trend scan to merge watchlist symbols, inspect combined title/text content and add dynamically discovered cashtags to the alias map so fresh tickers are considered
- add a helper for cashtag extraction and reuse the enriched alias set when counting mentions
- cover the new behaviour with a regression test that proves a previously unknown cashtag is detected

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8a9a2b100832591a9cf5774d6290c