### PR TITLE
Detect new cashtag trends

### DIFF
--- a/tests/test_trending.py
+++ b/tests/test_trending.py
@@ -1,5 +1,10 @@
 from datetime import datetime, timedelta, timezone
 
+import duckdb
+
+from wallenstein.db_schema import ensure_tables
+from wallenstein.trending import scan_reddit_for_candidates
+
 from wallenstein.reddit_scraper import detect_trending_tickers
 
 
@@ -19,3 +24,36 @@ def test_detect_trending_tickers():
     trending = detect_trending_tickers(data, window_hours=24, baseline_days=7, min_mentions=3, ratio=2.0)
     assert "AAA" in trending
     assert "BBB" not in trending
+
+
+def test_scan_candidates_detects_new_cashtag():
+    con = duckdb.connect(database=":memory:")
+    ensure_tables(con)
+
+    now = datetime.now(timezone.utc)
+    text = "New hype around $XYZ going to the moon"
+    rows = [
+        (
+            f"post-{i}",
+            now - timedelta(hours=i % 3),
+            f"Title {i}",
+            text,
+            10,
+        )
+        for i in range(6)
+    ]
+    con.executemany(
+        "INSERT INTO reddit_posts (id, created_utc, title, text, upvotes) VALUES (?, ?, ?, ?, ?)",
+        rows,
+    )
+
+    candidates = scan_reddit_for_candidates(
+        con,
+        lookback_days=2,
+        window_hours=24,
+        min_mentions=3,
+        min_lift=1.5,
+        k_smooth=0.5,
+    )
+
+    assert any(c.symbol == "XYZ" for c in candidates)

--- a/wallenstein/trending.py
+++ b/wallenstein/trending.py
@@ -83,6 +83,11 @@ def _match_with_patterns(text: str, patmap: dict[str, list[re.Pattern]]) -> set[
             if p.search(text):
                 hits.add(sym)
                 break
+    # Ergänze um frei erkannte Cashtags
+    for raw in CASHTAG_PATTERN.findall(text):
+        symbol = _normalise_symbol(raw)
+        if symbol:
+            hits.add(symbol)
     # Konflikte bei Überschneidungen (optional: längster Alias gewinnt)
     return hits
 
@@ -134,10 +139,7 @@ def scan_reddit_for_candidates(
     ensure_trending_tables(con)
     # include basic aliases plus WordNet synonyms for broader matching
     amap = alias_map(con, include_ticker_itself=True, use_synonyms=True)
-    if not amap:
-        return []
-
-    patmap = _compile_alias_patterns(amap)
+    patmap = _compile_alias_patterns(amap) if amap else {}
 
     # Fenster laden (UTC im DB; hier neutral belassen)
     cols = {row[1] for row in con.execute("PRAGMA table_info('reddit_posts')").fetchall()}
@@ -303,3 +305,20 @@ def auto_add_candidates_to_watchlist(
         except Exception:
             pass
     return added
+CASHTAG_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9])[#$]([A-Za-z][A-Za-z0-9]{0,4})(?![A-Za-z0-9])", re.IGNORECASE
+)
+
+
+def _normalise_symbol(sym: str) -> str | None:
+    symbol = sym.strip().upper()
+    if not symbol:
+        return None
+    if len(symbol) > 5:
+        return None
+    if not symbol.isalnum():
+        return None
+    if not any(ch.isalpha() for ch in symbol):
+        return None
+    return symbol
+


### PR DESCRIPTION
## Summary
- extend the Reddit trend scanner to harvest unknown cashtags by normalising matches and falling back when no aliases exist
- allow candidate detection without a pre-populated alias map so new symbols can surface in the trend tables
- cover the new behaviour with a unit test that simulates fresh cashtag activity

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68c930b5d9408325bece74b06bbf2b9a