### PR TITLE
Cache model training state to reduce runtime

### DIFF
--- a/tests/test_model_state.py
+++ b/tests/test_model_state.py
@@ -1,0 +1,87 @@
+from datetime import date, datetime
+
+import duckdb
+import pytest
+
+from wallenstein.db_schema import ensure_tables
+from wallenstein.model_state import (
+    TrainingSnapshot,
+    load_training_state,
+    should_skip_training,
+    upsert_training_state,
+)
+
+
+def test_training_state_roundtrip(tmp_path):
+    con = duckdb.connect(str(tmp_path / "state.duckdb"))
+    ensure_tables(con)
+
+    snapshot = TrainingSnapshot(
+        latest_price_date=date(2024, 1, 1),
+        price_row_count=10,
+        latest_sentiment_date=date(2024, 1, 2),
+        sentiment_row_count=5,
+        latest_post_utc=datetime(2024, 1, 3, 12, 0, 0),
+    )
+
+    upsert_training_state(
+        con,
+        "AAA",
+        snapshot,
+        accuracy=0.8,
+        f1=0.7,
+        roc_auc=0.75,
+        precision=0.65,
+        recall=0.6,
+    )
+
+    state = load_training_state(con)
+    assert "AAA" in state
+    loaded = state["AAA"]
+    assert loaded.snapshot.matches(snapshot)
+    assert loaded.accuracy == pytest.approx(0.8)
+    assert loaded.f1 == pytest.approx(0.7)
+    assert loaded.roc_auc == pytest.approx(0.75)
+    assert loaded.precision == pytest.approx(0.65)
+    assert loaded.recall == pytest.approx(0.6)
+    assert loaded.trained_at is not None
+
+    con.close()
+
+
+def test_should_skip_training(tmp_path):
+    con = duckdb.connect(str(tmp_path / "skip.duckdb"))
+    ensure_tables(con)
+
+    snapshot = TrainingSnapshot(
+        latest_price_date=date(2024, 2, 1),
+        price_row_count=12,
+        latest_sentiment_date=date(2024, 2, 2),
+        sentiment_row_count=6,
+        latest_post_utc=datetime(2024, 2, 3, 15, 30, 0),
+    )
+    upsert_training_state(
+        con,
+        "BBB",
+        snapshot,
+        accuracy=None,
+        f1=None,
+        roc_auc=None,
+        precision=None,
+        recall=None,
+    )
+
+    state = load_training_state(con)
+    existing = state["BBB"]
+    assert should_skip_training(existing, snapshot)
+
+    changed = TrainingSnapshot(
+        latest_price_date=date(2024, 2, 2),
+        price_row_count=13,
+        latest_sentiment_date=date(2024, 2, 2),
+        sentiment_row_count=6,
+        latest_post_utc=datetime(2024, 2, 3, 15, 30, 0),
+    )
+    assert not should_skip_training(existing, changed)
+
+    con.close()

--- a/wallenstein/db_schema.py
+++ b/wallenstein/db_schema.py
@@ -79,6 +79,20 @@ SCHEMAS = {
         "price": "DOUBLE",
         "active": "BOOLEAN",
     },
+    "model_training_state": {
+        "ticker": "TEXT",
+        "latest_price_date": "DATE",
+        "price_row_count": "INTEGER",
+        "latest_sentiment_date": "DATE",
+        "sentiment_row_count": "INTEGER",
+        "latest_post_utc": "TIMESTAMP",
+        "trained_at": "TIMESTAMP",
+        "accuracy": "DOUBLE",
+        "f1": "DOUBLE",
+        "roc_auc": "DOUBLE",
+        "precision_score": "DOUBLE",
+        "recall_score": "DOUBLE",
+    },
 }
 
 
@@ -91,6 +105,8 @@ def ensure_tables(con: duckdb.DuckDBPyConnection):
             coldefs += ", PRIMARY KEY (date, ticker)"
         if table == "alerts":
             coldefs += ", PRIMARY KEY (id)"
+        if table == "model_training_state":
+            coldefs += ", PRIMARY KEY (ticker)"
         if table == "reddit_sentiment_hourly":
             coldefs += ", PRIMARY KEY (ticker, created_utc)"
         if table == "reddit_sentiment_daily":

--- a/wallenstein/model_state.py
+++ b/wallenstein/model_state.py
@@ -1,0 +1,187 @@
+"""Utilities for persisting per-ticker model training state."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Dict, Optional
+
+import duckdb
+
+
+@dataclass(frozen=True)
+class TrainingSnapshot:
+    """Aggregated information about the data used for training a ticker."""
+
+    latest_price_date: Optional[date]
+    price_row_count: int
+    latest_sentiment_date: Optional[date]
+    sentiment_row_count: int
+    latest_post_utc: Optional[datetime]
+
+    def matches(self, other: "TrainingSnapshot") -> bool:
+        """Return ``True`` if both snapshots describe the same dataset."""
+
+        return (
+            self.latest_price_date == other.latest_price_date
+            and self.price_row_count == other.price_row_count
+            and self.latest_sentiment_date == other.latest_sentiment_date
+            and self.sentiment_row_count == other.sentiment_row_count
+            and self.latest_post_utc == other.latest_post_utc
+        )
+
+
+@dataclass
+class TrainingState:
+    """Persisted model state including metrics from the last training run."""
+
+    snapshot: TrainingSnapshot
+    trained_at: Optional[datetime]
+    accuracy: Optional[float]
+    f1: Optional[float]
+    roc_auc: Optional[float]
+    precision: Optional[float]
+    recall: Optional[float]
+
+
+def load_training_state(con: duckdb.DuckDBPyConnection) -> Dict[str, TrainingState]:
+    """Return the stored training state for all tickers."""
+
+    try:
+        rows = con.execute(
+            """
+            SELECT
+                ticker,
+                latest_price_date,
+                price_row_count,
+                latest_sentiment_date,
+                sentiment_row_count,
+                latest_post_utc,
+                trained_at,
+                accuracy,
+                f1,
+                roc_auc,
+                precision_score,
+                recall_score
+            FROM model_training_state
+            """
+        ).fetchall()
+    except duckdb.Error:
+        return {}
+
+    state: Dict[str, TrainingState] = {}
+    for row in rows:
+        snapshot = TrainingSnapshot(
+            latest_price_date=row[1],
+            price_row_count=int(row[2]) if row[2] is not None else 0,
+            latest_sentiment_date=row[3],
+            sentiment_row_count=int(row[4]) if row[4] is not None else 0,
+            latest_post_utc=row[5],
+        )
+        state[row[0]] = TrainingState(
+            snapshot=snapshot,
+            trained_at=row[6],
+            accuracy=row[7],
+            f1=row[8],
+            roc_auc=row[9],
+            precision=row[10],
+            recall=row[11],
+        )
+    return state
+
+
+def should_skip_training(
+    existing: Optional[TrainingState], snapshot: TrainingSnapshot
+) -> bool:
+    """Return ``True`` when ``snapshot`` matches ``existing``."""
+
+    if existing is None:
+        return False
+    return existing.snapshot.matches(snapshot)
+
+
+def upsert_training_state(
+    con: duckdb.DuckDBPyConnection,
+    ticker: str,
+    snapshot: TrainingSnapshot,
+    *,
+    accuracy: Optional[float],
+    f1: Optional[float],
+    roc_auc: Optional[float],
+    precision: Optional[float],
+    recall: Optional[float],
+) -> None:
+    """Insert or update the stored training state for ``ticker``."""
+
+    con.execute(
+        """
+        MERGE INTO model_training_state AS target
+        USING (
+            SELECT
+                ? AS ticker,
+                ? AS latest_price_date,
+                ? AS price_row_count,
+                ? AS latest_sentiment_date,
+                ? AS sentiment_row_count,
+                ? AS latest_post_utc,
+                CURRENT_TIMESTAMP AS trained_at,
+                ? AS accuracy,
+                ? AS f1,
+                ? AS roc_auc,
+                ? AS precision_score,
+                ? AS recall_score
+        ) AS src
+        ON target.ticker = src.ticker
+        WHEN MATCHED THEN UPDATE SET
+            latest_price_date = src.latest_price_date,
+            price_row_count = src.price_row_count,
+            latest_sentiment_date = src.latest_sentiment_date,
+            sentiment_row_count = src.sentiment_row_count,
+            latest_post_utc = src.latest_post_utc,
+            trained_at = src.trained_at,
+            accuracy = src.accuracy,
+            f1 = src.f1,
+            roc_auc = src.roc_auc,
+            precision_score = src.precision_score,
+            recall_score = src.recall_score
+        WHEN NOT MATCHED THEN INSERT (
+            ticker,
+            latest_price_date,
+            price_row_count,
+            latest_sentiment_date,
+            sentiment_row_count,
+            latest_post_utc,
+            trained_at,
+            accuracy,
+            f1,
+            roc_auc,
+            precision_score,
+            recall_score
+        ) VALUES (
+            src.ticker,
+            src.latest_price_date,
+            src.price_row_count,
+            src.latest_sentiment_date,
+            src.sentiment_row_count,
+            src.latest_post_utc,
+            src.trained_at,
+            src.accuracy,
+            src.f1,
+            src.roc_auc,
+            src.precision_score,
+            src.recall_score
+        )
+        """,
+        [
+            ticker,
+            snapshot.latest_price_date,
+            snapshot.price_row_count,
+            snapshot.latest_sentiment_date,
+            snapshot.sentiment_row_count,
+            snapshot.latest_post_utc,
+            accuracy,
+            f1,
+            roc_auc,
+            precision,
+            recall,
+        ],
+    )


### PR DESCRIPTION
## Summary
- Skip per-ticker model training when no new price, sentiment or Reddit signals are available by computing training snapshots in the pipeline
- Persist the last-used training metadata in a new `model_training_state` table with dedicated helper utilities
- Add unit coverage for the model training state helpers to ensure round-tripping and skip decisions work as expected

## Testing
- PYTHONPATH=. pytest tests/test_model_state.py
- PYTHONPATH=. pytest tests/test_stock_data.py

------
https://chatgpt.com/codex/tasks/task_e_68ca8a191b008325838eac1f76e9338d