### PR TITLE
Speed up CI dependency install

### DIFF
--- a/.github/workflows/run_script.yml
+++ b/.github/workflows/run_script.yml
@@ -44,13 +44,15 @@ jobs:
           python-version: "3.11"
           cache: "pip"
           cache-dependency-path: |
+            requirements-base.txt
+            requirements-ml.txt
             requirements.txt
-            **/requirements.txt
+            **/requirements*.txt
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install --no-cache-dir --upgrade -r requirements.txt
+          pip install --upgrade -r requirements-base.txt
 
       - name: Prepare folders
         run: mkdir -p data stockOverview
@@ -59,7 +61,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: nltk_data
-          key: ${{ runner.os }}-nltk-${{ hashFiles('**/requirements.txt') }}
+          key: ${{ runner.os }}-nltk-${{ hashFiles('requirements-base.txt', 'requirements-ml.txt') }}
         continue-on-error: true
 
       - name: Restore previous DuckDB (optional)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ Broker-target support is temporarily disabled pending a new data provider.
 
 ## Quickstart
 ```bash
-pip install -r requirements.txt
+pip install -r requirements-base.txt
+# Optional FinBERT/Optuna extras:
+# pip install -r requirements-ml.txt
 # The VADER lexicon downloads automatically on first run; pre-download it for
 # offline use with the following command (optional):
 python -m nltk.downloader vader_lexicon
@@ -22,20 +24,23 @@ The main pipeline reads symbols from the watchlist and exits with a warning if n
 
 ## Install (reproducible)
 
-Pinned dependencies live in `requirements.txt`.
+Core dependencies live in `requirements-base.txt`. Heavy ML extras (FinBERT,
+HuggingFace, Optuna) are separated into `requirements-ml.txt` so that the CI
+pipeline can skip them. For a minimal install run:
 
 ```bash
-pip install -r requirements.txt
+pip install -r requirements-base.txt
 ```
 
-An optional `requirements.in` is provided for use with
-[`pip-tools`](https://github.com/jazzband/pip-tools). Regenerate the pinned
-file via:
+To enable the transformer-based sentiment analysis or Optuna-based hyperparameter
+search also install:
 
 ```bash
-pip install pip-tools
-pip-compile requirements.in
+pip install -r requirements-ml.txt
 ```
+
+`requirements.txt` includes both sets for convenience when the full environment
+is desired.
 
 ## Dev setup
 

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -1,0 +1,14 @@
+pandas
+yfinance
+duckdb
+sqlparse
+requests
+python-dotenv
+pyyaml
+praw
+langdetect
+nltk
+scikit-learn
+imbalanced-learn
+vaderSentiment
+python-telegram-bot

--- a/requirements-ml.txt
+++ b/requirements-ml.txt
@@ -1,0 +1,6 @@
+transformers
+huggingface_hub
+tokenizers
+torch
+optuna
+optuna-integration[sklearn]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,25 +1,4 @@
-pandas
-yfinance
-duckdb
-sqlparse
-requests
-python-dotenv
-pyyaml
-
-praw
-langdetect
-nltk
-
-scikit-learn
-imbalanced-learn
-
-transformers
-huggingface_hub
-tokenizers
-vaderSentiment
-torch
-
-optuna
-optuna-integration[sklearn]
-
-python-telegram-bot
+# Default install includes both the lightweight core and optional ML extras.
+# ``pip install -r requirements-base.txt`` installs the fast core only.
+-r requirements-base.txt
+-r requirements-ml.txt


### PR DESCRIPTION
## Summary
- split the dependency list into lightweight core and optional ML extras and document the new install paths
- adjust the CI workflow to use pip caching and install only the cached core requirements

## Testing
- pytest *(fails: SyntaxError in tests/test_trending.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ca8b5082c08325a2fe78e9bd32f962