### PR TITLE
Optimize sentiment processing to reduce pipeline runtime

### DIFF
--- a/tests/test_sentiment_aggregation.py
+++ b/tests/test_sentiment_aggregation.py
@@ -16,12 +16,18 @@ if str(ROOT) not in sys.path:
 import importlib
 
 import wallenstein.sentiment as sentiment
+import wallenstein.sentiment_analysis as sentiment_analysis
 
 
 @pytest.fixture(autouse=True)
 def _disable_bert(monkeypatch):
     """Ensure keyword-based sentiment to keep tests light."""
     monkeypatch.setattr(sentiment.settings, "USE_BERT_SENTIMENT", False)
+    monkeypatch.setattr(
+        sentiment_analysis,
+        "analyze_sentiment_many",
+        lambda texts, batch_size=32: [0.0 for _ in texts],
+    )
 
 
 def test_aggregate_handles_nan_values():


### PR DESCRIPTION
## Summary
- add batched sentiment inference to `SentimentEngine` and expose an `analyze_sentiment_many` helper
- precompute and persist Reddit post sentiment scores during the pipeline so aggregation and training reuse the same values
- adjust the sentiment aggregation test fixture to stub the new batch analyzer for lightweight execution

## Testing
- pytest *(fails: SyntaxError in existing tests/test_trending.py)*
- pytest tests/test_sentiment_aggregation.py -q


------
https://chatgpt.com/codex/tasks/task_e_68caa5e350d48325aeb5d62babec4466