### PR TITLE
Enhance sentiment and ML modelling with weekly trend metrics

### DIFF
--- a/main.py
+++ b/main.py
@@ -351,11 +351,17 @@ def generate_trends(reddit_posts: dict[str, list]) -> None:
                 known = [c for c in cands if getattr(c, "is_known", True)]
                 unknown = [c for c in cands if not getattr(c, "is_known", True)]
                 if known:
+                    def _format_candidate(cand):
+                        weekly = getattr(cand, "weekly_return", None)
+                        if weekly is None:
+                            return f"{cand.symbol} (m24h={cand.mentions_24h}, x{cand.lift:.1f})"
+                        return (
+                            f"{cand.symbol} (m24h={cand.mentions_24h}, x{cand.lift:.1f}, "
+                            f"7d {weekly * 100:+.1f}%)"
+                        )
+
                     top_preview = ", ".join(
-                        [
-                            f"{c.symbol} (m24h={c.mentions_24h}, x{c.lift:.1f})"
-                            for c in known[:5]
-                        ]
+                        [_format_candidate(c) for c in known[:5]]
                     )
                     log.info(f"Trending-Kandidaten (Top 5, verifiziert): {top_preview}")
                     notify_telegram("🔥 Reddit-Trends: " + top_preview)


### PR DESCRIPTION
## Summary
- blend FinBERT outputs with VADER and keyword boosts for more robust sentiment scoring, including batch handling
- expand per-stock model features with momentum signals and tune the decision threshold using predicted probabilities
- enrich trend scanning with seven-day return data (fetched from stored prices or yfinance) and surface it in notifications, with regression tests

## Testing
- pytest tests/test_sentiment.py tests/test_sentiment_analysis.py tests/test_models.py tests/test_trending.py

------
https://chatgpt.com/codex/tasks/task_e_68d168d4cbd08325a1c38fecad66e8e5