### PR TITLE
Promote discovered trend symbols before fetching data

### DIFF
--- a/main.py
+++ b/main.py
@@ -87,6 +87,7 @@ from wallenstein.sentiment_analysis import analyze_sentiment_many
 from wallenstein.stock_data import purge_old_prices, update_fx_rates, update_prices
 from wallenstein.trending import (
     auto_add_candidates_to_watchlist,
+    fetch_weekly_returns,
     scan_reddit_for_candidates,
 )
 
@@ -351,11 +352,32 @@ def generate_trends(reddit_posts: dict[str, list]) -> None:
                 known = [c for c in cands if getattr(c, "is_known", True)]
                 unknown = [c for c in cands if not getattr(c, "is_known", True)]
                 if known:
+                    missing_weekly = [
+                        c.symbol for c in known if getattr(c, "weekly_return", None) is None
+                    ]
+                    weekly_fallback: dict[str, float] = {}
+                    if missing_weekly:
+                        try:
+                            weekly_fallback = fetch_weekly_returns(
+                                con,
+                                missing_weekly,
+                                max_symbols=len(missing_weekly),
+                            )
+                        except Exception as exc:  # pragma: no cover - best effort
+                            log.debug("Weekly return lookup failed: %s", exc)
+                            weekly_fallback = {}
+
+                    def _format_candidate(cand):
+                        weekly = getattr(cand, "weekly_return", None)
+                        if weekly is None and weekly_fallback:
+                            weekly = weekly_fallback.get(cand.symbol.upper())
+                        base = f"{cand.symbol} (m24h={cand.mentions_24h}, x{cand.lift:.1f})"
+                        if weekly is not None:
+                            base += f", 7d {weekly * 100:+.1f}%"
+                        return base
+
                     top_preview = ", ".join(
-                        [
-                            f"{c.symbol} (m24h={c.mentions_24h}, x{c.lift:.1f})"
-                            for c in known[:5]
-                        ]
+                        [_format_candidate(c) for c in known[:5]]
                     )
                     log.info(f"Trending-Kandidaten (Top 5, verifiziert): {top_preview}")
                     notify_telegram("🔥 Reddit-Trends: " + top_preview)

--- a/tests/test_main_generate_trends.py
+++ b/tests/test_main_generate_trends.py
@@ -1,0 +1,64 @@
+import importlib
+import os
+import sys
+import types
+
+
+def test_hourly_trend_preview_includes_weekly(tmp_path, monkeypatch):
+    os.environ.setdefault("REDDIT_CLIENT_ID", "x")
+    os.environ.setdefault("REDDIT_CLIENT_SECRET", "x")
+    os.environ.setdefault("REDDIT_USER_AGENT", "x")
+
+    if "main" in sys.modules:
+        main = importlib.reload(sys.modules["main"])
+    else:
+        main = importlib.import_module("main")
+
+    db_path = tmp_path / "telegram_trends.duckdb"
+    monkeypatch.setattr(main, "DB_PATH", str(db_path), raising=False)
+    main.init_schema(str(db_path))
+
+    monkeypatch.setattr(main, "enrich_reddit_posts", lambda *args, **kwargs: 0)
+    monkeypatch.setattr(main, "compute_reddit_trends", lambda *args, **kwargs: 0)
+    monkeypatch.setattr(main, "compute_returns", lambda *args, **kwargs: 0)
+    monkeypatch.setattr(
+        main, "compute_reddit_sentiment", lambda *args, **kwargs: (0, 0)
+    )
+
+    messages: list[str] = []
+
+    def fake_notify(message: str) -> bool:
+        messages.append(message)
+        return True
+
+    monkeypatch.setattr(main, "notify_telegram", fake_notify)
+
+    candidate = types.SimpleNamespace(
+        symbol="AAPL",
+        mentions_24h=42,
+        lift=3.4,
+        trend=9.1,
+        is_known=True,
+        weekly_return=None,
+    )
+
+    monkeypatch.setattr(
+        main,
+        "scan_reddit_for_candidates",
+        lambda *args, **kwargs: [candidate],
+    )
+    monkeypatch.setattr(
+        main,
+        "auto_add_candidates_to_watchlist",
+        lambda *args, **kwargs: [],
+    )
+    monkeypatch.setattr(
+        main,
+        "fetch_weekly_returns",
+        lambda *args, **kwargs: {"AAPL": 0.05},
+    )
+
+    main.generate_trends({"AAPL": [{"id": "p1"}]})
+
+    assert messages, "hourly notification was not emitted"
+    assert "7d +5.0%" in messages[0]

--- a/tests/test_trending.py
+++ b/tests/test_trending.py
@@ -1,11 +1,19 @@
 from datetime import datetime, timedelta, timezone
 
 import duckdb
+import pytest
 
 from wallenstein.aliases import add_alias
 from wallenstein.db_schema import ensure_tables
 from wallenstein.reddit_scraper import detect_trending_tickers
+import wallenstein.trending as trending
+from wallenstein.ticker_detection import TickerMetadata
 from wallenstein.trending import scan_reddit_for_candidates
+
+
+@pytest.fixture(autouse=True)
+def disable_discovery(monkeypatch):
+    monkeypatch.setattr(trending, "discover_new_tickers", lambda *args, **kwargs: {})
 
 
 def test_detect_trending_tickers():
@@ -63,6 +71,42 @@ def test_scan_candidates_detects_new_symbol_marked_unknown():
     assert new_candidate.is_known is False
 
 
+def test_scan_candidates_promotes_discovered_symbol(monkeypatch):
+    con = duckdb.connect(database=":memory:")
+    ensure_tables(con)
+
+    now = datetime.now(timezone.utc)
+    rows = [
+        ("p1", now - timedelta(hours=1), "🚀 $NEW to the moon", "", 42),
+        ("p2", now - timedelta(hours=2), "$NEW again", "", 30),
+    ]
+    _insert_posts(con, rows)
+
+    meta = TickerMetadata(symbol="NEW", aliases={"New Holdings"})
+
+    def fake_discover(texts, known=None, **kwargs):
+        return {"NEW": meta}
+
+    monkeypatch.setattr(trending, "discover_new_tickers", fake_discover)
+
+    candidates = scan_reddit_for_candidates(
+        con,
+        lookback_days=2,
+        window_hours=24,
+        min_mentions=1,
+        min_lift=1.0,
+    )
+
+    new_candidate = next(c for c in candidates if c.symbol == "NEW")
+    assert new_candidate.is_known is True
+
+    aliases = con.execute(
+        "SELECT alias FROM ticker_aliases WHERE ticker = 'NEW' ORDER BY alias"
+    ).fetchall()
+    stored = {row[0] for row in aliases}
+    assert {"NEW", "New Holdings"} <= stored
+
+
 def test_scan_candidates_marks_known_symbols():
     con = duckdb.connect(database=":memory:")
     ensure_tables(con)
@@ -109,3 +153,122 @@ def test_scan_candidates_handles_dot_symbol():
 
     brkb_candidate = next(c for c in candidates if c.symbol == "BRK.B")
     assert brkb_candidate.is_known is True
+
+
+def test_scan_candidates_adds_weekly_return_from_prices():
+    con = duckdb.connect(database=":memory:")
+    ensure_tables(con)
+
+    add_alias(con, "TSLA", "tesla")
+    now = datetime.now(timezone.utc)
+    rows = [
+        ("p1", now - timedelta(hours=1), "$TSLA rockets", "", 18),
+        ("p2", now - timedelta(hours=3), "Holding TSLA", "", 7),
+    ]
+    _insert_posts(con, rows)
+
+    price_rows = [
+        (
+            (now - timedelta(days=7)).date(),
+            "TSLA",
+            100.0,
+            105.0,
+            99.0,
+            102.0,
+            102.0,
+            1_000,
+        ),
+        (
+            now.date(),
+            "TSLA",
+            110.0,
+            115.0,
+            108.0,
+            112.0,
+            112.0,
+            1_200,
+        ),
+    ]
+    con.executemany(
+        """
+        INSERT INTO prices (date, ticker, open, high, low, close, adj_close, volume)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        price_rows,
+    )
+
+    candidates = scan_reddit_for_candidates(
+        con,
+        lookback_days=2,
+        window_hours=24,
+        min_mentions=1,
+        min_lift=1.0,
+    )
+
+    tsla_candidate = next(c for c in candidates if c.symbol == "TSLA")
+    assert tsla_candidate.weekly_return is not None
+    expected = 112.0 / 102.0 - 1
+    assert tsla_candidate.weekly_return == pytest.approx(expected, rel=1e-3)
+
+
+def test_scan_candidates_prefers_display_order_for_weekly(monkeypatch):
+    """Top candidates should receive weekly returns even with many symbols."""
+
+    con = duckdb.connect(database=":memory:")
+    ensure_tables(con)
+
+    tickers = [
+        "AAPL",
+        "AMD",
+        "AMZN",
+        "BABA",
+        "GME",
+        "GOOG",
+        "META",
+        "MSFT",
+        "NIO",
+        "NVDA",
+        "PLTR",
+        "TSLA",
+    ]
+
+    now = datetime.now(timezone.utc)
+    for t in tickers:
+        add_alias(con, t, t.lower())
+
+    rows = []
+    for idx, ticker in enumerate(tickers):
+        for j in range(idx + 1):
+            rows.append(
+                (
+                    f"{ticker}{j}",
+                    now - timedelta(hours=j + 1),
+                    f"$ {ticker}",
+                    "",
+                    5,
+                )
+            )
+    _insert_posts(con, rows)
+
+    monkeypatch.setattr(trending, "_weekly_return_from_db", lambda *_: None)
+    weekly_values = {"TSLA": 0.42, "PLTR": 0.21}
+    monkeypatch.setattr(
+        trending,
+        "_weekly_return_from_yfinance",
+        lambda symbol: weekly_values.get(symbol, 0.0),
+    )
+
+    candidates = scan_reddit_for_candidates(
+        con,
+        lookback_days=7,
+        window_hours=24,
+        min_mentions=1,
+        min_lift=1.0,
+    )
+
+    top_symbols = [c.symbol for c in candidates[:2]]
+    assert "TSLA" in top_symbols and "PLTR" in top_symbols
+
+    for sym in ("TSLA", "PLTR"):
+        cand = next(c for c in candidates if c.symbol == sym)
+        assert cand.weekly_return == pytest.approx(weekly_values[sym])


### PR DESCRIPTION
## Summary
- attempt to validate newly detected trend symbols via the ticker discovery helper so candidates are marked as known once metadata exists
- persist auto-discovered aliases for promoted symbols and re-run weekly data enrichment with the updated candidate list
- cover the promotion path with regression tests while stubbing discovery in other trend tests

## Testing
- PYTHONPATH=. pytest tests/test_trending.py

------
https://chatgpt.com/codex/tasks/task_e_68d168d4cbd08325a1c38fecad66e8e5