### PR TITLE
Fix weekly trend price display

### DIFF
--- a/main.py
+++ b/main.py
@@ -376,15 +376,6 @@ def generate_trends(reddit_posts: dict[str, list]) -> None:
                             base += f", 7d {weekly * 100:+.1f}%"
                         return base
 
-                    def _format_candidate(cand):
-                        weekly = getattr(cand, "weekly_return", None)
-                        if weekly is None:
-                            return f"{cand.symbol} (m24h={cand.mentions_24h}, x{cand.lift:.1f})"
-                        return (
-                            f"{cand.symbol} (m24h={cand.mentions_24h}, x{cand.lift:.1f}, "
-                            f"7d {weekly * 100:+.1f}%)"
-                        )
-
                     top_preview = ", ".join(
                         [_format_candidate(c) for c in known[:5]]
                     )

--- a/wallenstein/trending.py
+++ b/wallenstein/trending.py
@@ -487,26 +487,6 @@ def scan_reddit_for_candidates(
             if cand.symbol in weekly_returns:
                 cand.weekly_return = weekly_returns[cand.symbol]
 
-    if candidates:
-        symbols_for_returns = {c.symbol for c in candidates if c.is_known}
-        if not symbols_for_returns:
-            symbols_for_returns = {c.symbol for c in candidates}
-        weekly_returns: dict[str, float] = {}
-        for sym in sorted(symbols_for_returns):
-            if len(weekly_returns) >= 10:
-                break
-            val = _weekly_return_from_db(con, sym)
-            if val is None:
-                val = _weekly_return_from_yfinance(sym)
-            if val is not None:
-                weekly_returns[sym] = val
-        if weekly_returns:
-            for cand in candidates:
-                if cand.symbol in weekly_returns:
-                    cand.weekly_return = weekly_returns[cand.symbol]
-
-
-
     # Persistenz
     known_candidates = [c for c in sorted_candidates if c.is_known]
     if unknown_symbols:


### PR DESCRIPTION
## Summary
- ensure the hourly trend notification keeps the fetched weekly returns fallback instead of overriding it
- remove the redundant manual weekly return lookup inside the Reddit trend scanner

## Testing
- PYTHONPATH=. pytest tests/test_main_generate_trends.py -q
- PYTHONPATH=. pytest tests/test_trending.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d1cbb608548325a7fd32faf930f2ac