### PR TITLE
Show weekly returns in overview message

### DIFF
--- a/main.py
+++ b/main.py
@@ -376,15 +376,6 @@ def generate_trends(reddit_posts: dict[str, list]) -> None:
                             base += f", 7d {weekly * 100:+.1f}%"
                         return base
 
-                    def _format_candidate(cand):
-                        weekly = getattr(cand, "weekly_return", None)
-                        if weekly is None:
-                            return f"{cand.symbol} (m24h={cand.mentions_24h}, x{cand.lift:.1f})"
-                        return (
-                            f"{cand.symbol} (m24h={cand.mentions_24h}, x{cand.lift:.1f}, "
-                            f"7d {weekly * 100:+.1f}%)"
-                        )
-
                     top_preview = ", ".join(
                         [_format_candidate(c) for c in known[:5]]
                     )

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -4,6 +4,9 @@ import duckdb
 
 os.environ.setdefault('CLIENT_ID', 'x')
 os.environ.setdefault('CLIENT_SECRET', 'x')
+os.environ.setdefault('REDDIT_CLIENT_ID', 'x')
+os.environ.setdefault('REDDIT_CLIENT_SECRET', 'x')
+os.environ.setdefault('REDDIT_USER_AGENT', 'x')
 os.environ.setdefault('TELEGRAM_BOT_TOKEN', 'x')
 
 from wallenstein.overview import generate_overview
@@ -14,6 +17,10 @@ def test_generate_overview_starts_with_chart_emoji(monkeypatch):
         return {t: (1.11 if use_eur else 2.22) for t in tickers}
 
     monkeypatch.setattr('wallenstein.overview.get_latest_prices', fake_get_latest_prices)
+    monkeypatch.setattr(
+        'wallenstein.overview.fetch_weekly_returns',
+        lambda *args, **kwargs: {str(sym).upper(): 0.05 for sym in args[1]},
+    )
 
     result = generate_overview(['NVDA'], reddit_posts={'NVDA': []})
     assert result.startswith("📊 Wallenstein Übersicht\n")
@@ -26,6 +33,10 @@ def test_generate_overview_fetches_missing_price(monkeypatch):
     monkeypatch.setattr('wallenstein.overview.get_latest_prices', fake_get_latest_prices)
     monkeypatch.setattr('wallenstein.overview._fetch_latest_price', lambda t: 42.0)
     monkeypatch.setattr('wallenstein.overview._fetch_usd_per_eur_rate', lambda: 2.0)
+    monkeypatch.setattr(
+        'wallenstein.overview.fetch_weekly_returns',
+        lambda *args, **kwargs: {str(sym).upper(): 0.05 for sym in args[1]},
+    )
 
     result = generate_overview(['MSFT'], reddit_posts={'MSFT': []})
     assert 'MSFT: 42.00 USD (21.00 EUR)' in result
@@ -47,6 +58,10 @@ def test_generate_overview_includes_latest_sentiment(monkeypatch, tmp_path):
         lambda db_path, tickers, use_eur=False: {t: 1.0 for t in tickers},
     )
     monkeypatch.setattr('wallenstein.overview.DB_PATH', str(db_path))
+    monkeypatch.setattr(
+        'wallenstein.overview.fetch_weekly_returns',
+        lambda *args, **kwargs: {str(sym).upper(): 0.05 for sym in args[1]},
+    )
 
     result = generate_overview(['NVDA'], reddit_posts={'NVDA': []})
     assert 'Sentiment (1d, weighted): +0.50' in result
@@ -68,6 +83,10 @@ def test_generate_overview_lists_aliases(monkeypatch, tmp_path):
         lambda db_path, tickers, use_eur=False: {t: 1.0 for t in tickers},
     )
     monkeypatch.setattr('wallenstein.overview.DB_PATH', str(db_path))
+    monkeypatch.setattr(
+        'wallenstein.overview.fetch_weekly_returns',
+        lambda *args, **kwargs: {str(sym).upper(): 0.05 for sym in args[1]},
+    )
 
     result = generate_overview(['NVDA'], reddit_posts={'NVDA': []})
     assert 'Alias: nvidia' in result
@@ -89,10 +108,15 @@ def test_generate_overview_includes_trending_section(monkeypatch, tmp_path):
         lambda db_path, tickers, use_eur=False: {t: 1.0 for t in tickers},
     )
     monkeypatch.setattr('wallenstein.overview.DB_PATH', str(db_path))
+    monkeypatch.setattr(
+        'wallenstein.overview.fetch_weekly_returns',
+        lambda *args, **kwargs: {str(sym).upper(): 0.05 for sym in args[1]},
+    )
 
     result = generate_overview(['TSLA'], reddit_posts={'TSLA': []})
     assert '🔥 Trends heute' in result
     assert '- TSLA: 5 Mentions' in result
+    assert '7d +5.0%' in result
 
 
 def test_generate_overview_lists_multi_hits(monkeypatch, tmp_path):
@@ -104,9 +128,31 @@ def test_generate_overview_lists_multi_hits(monkeypatch, tmp_path):
         lambda db_path, tickers, use_eur=False: {t: 1.0 for t in tickers},
     )
     monkeypatch.setattr('wallenstein.overview.DB_PATH', str(db_path))
+    monkeypatch.setattr(
+        'wallenstein.overview.fetch_weekly_returns',
+        lambda *args, **kwargs: {str(sym).upper(): 0.05 for sym in args[1]},
+    )
 
     result = generate_overview(
         ['NVDA'], reddit_posts={'NVDA': [{}, {}]}
     )
     assert '🔁 Mehrfach erwähnt' in result
     assert '- NVDA: 2 Posts' in result
+
+
+def test_generate_overview_includes_weekly_line(monkeypatch, tmp_path):
+    db_path = tmp_path / 'db.duckdb'
+    duckdb.connect(str(db_path)).close()
+
+    monkeypatch.setattr(
+        'wallenstein.overview.get_latest_prices',
+        lambda db_path, tickers, use_eur=False: {t: 10.0 for t in tickers},
+    )
+    monkeypatch.setattr('wallenstein.overview.DB_PATH', str(db_path))
+    monkeypatch.setattr(
+        'wallenstein.overview.fetch_weekly_returns',
+        lambda *args, **kwargs: {str(sym).upper(): 0.12 for sym in args[1]},
+    )
+
+    result = generate_overview(['AMZN'], reddit_posts={'AMZN': []})
+    assert 'Kurs (7d): +12.0%' in result

--- a/wallenstein/trending.py
+++ b/wallenstein/trending.py
@@ -487,26 +487,6 @@ def scan_reddit_for_candidates(
             if cand.symbol in weekly_returns:
                 cand.weekly_return = weekly_returns[cand.symbol]
 
-    if candidates:
-        symbols_for_returns = {c.symbol for c in candidates if c.is_known}
-        if not symbols_for_returns:
-            symbols_for_returns = {c.symbol for c in candidates}
-        weekly_returns: dict[str, float] = {}
-        for sym in sorted(symbols_for_returns):
-            if len(weekly_returns) >= 10:
-                break
-            val = _weekly_return_from_db(con, sym)
-            if val is None:
-                val = _weekly_return_from_yfinance(sym)
-            if val is not None:
-                weekly_returns[sym] = val
-        if weekly_returns:
-            for cand in candidates:
-                if cand.symbol in weekly_returns:
-                    cand.weekly_return = weekly_returns[cand.symbol]
-
-
-
     # Persistenz
     known_candidates = [c for c in sorted_candidates if c.is_known]
     if unknown_symbols:


### PR DESCRIPTION
## Summary
- include weekly return data in the daily overview message for both the trending summary and the watched tickers
- extend the overview tests to stub weekly returns, cover the new weekly output, and ensure required environment defaults are set

## Testing
- PYTHONPATH=. pytest tests/test_overview.py tests/test_main_generate_trends.py tests/test_trending.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d1cbb608548325a7fd32faf930f2ac