### PR TITLE
Improve ML buy signal metadata and overview presentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,5 @@
 - `scripts/evaluate_sentiment.py` evaluates keyword, baseline FinBERT and fine-tuned FinBERT models.
 - Added placeholder directory `models/finetuned-finbert` for trained weights.
 - Removed deprecated functions `_select_latest_prices` and `get_latest_prices_auto` from `wallenstein.db_utils`.
+- Stored ML-based buy signals with probabilities/backtests and surfaced them in the overview output.
+- Enriched ML buy-signal metadata with expected returns, win rates and calibration details; overview now highlights expected vs. backtested performance.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This is a ready-to-push bundle. It includes:
 - Robust price updater with DuckDB storage (Stooq default with Yahoo/Stooq fallback)
 - Reddit sentiment integration (PRAW) with basic English/German keyword analysis
 - Telegram alerts (optional)
+- Machine-learning buy signals with calibrated probability, expected return, backtest win-rate and overview summary
 
 Broker-target support is temporarily disabled pending a new data provider.
 

--- a/tests/test_model_state.py
+++ b/tests/test_model_state.py
@@ -33,6 +33,8 @@ def test_training_state_roundtrip(tmp_path):
         roc_auc=0.75,
         precision=0.65,
         recall=0.6,
+        avg_strategy_return=0.012,
+        long_win_rate=0.55,
     )
 
     state = load_training_state(con)
@@ -44,6 +46,8 @@ def test_training_state_roundtrip(tmp_path):
     assert loaded.roc_auc == pytest.approx(0.75)
     assert loaded.precision == pytest.approx(0.65)
     assert loaded.recall == pytest.approx(0.6)
+    assert loaded.avg_strategy_return == pytest.approx(0.012)
+    assert loaded.long_win_rate == pytest.approx(0.55)
     assert loaded.trained_at is not None
 
     con.close()
@@ -69,6 +73,8 @@ def test_should_skip_training(tmp_path):
         roc_auc=None,
         precision=None,
         recall=None,
+        avg_strategy_return=None,
+        long_win_rate=None,
     )
 
     state = load_training_state(con)


### PR DESCRIPTION
## Summary
- extend the per-ticker ML training metadata with expected next-day return, long trade win rate, probability margin and sample sizes
- persist the richer metadata in DuckDB (schema migration + training state upsert) and surface it in the overview as expected/backtest performance details
- refresh docs/tests to reflect the enriched buy signal output and new training state columns

## Testing
- pytest tests/test_models.py tests/test_model_state.py tests/test_overview.py

------
https://chatgpt.com/codex/tasks/task_e_68d3c145bd0c832585a625e4f8f6f330