### PR TITLE
Improve Telegram overview clarity and restore ML signals

### DIFF
--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -23,7 +23,7 @@ def test_generate_overview_starts_with_chart_emoji(monkeypatch):
     )
 
     result = generate_overview(['NVDA'], reddit_posts={'NVDA': []})
-    assert result.startswith("📊 Wallenstein Übersicht\n")
+    assert result.startswith("📊 Wallenstein Markt-Update\n")
 
 
 def test_generate_overview_fetches_missing_price(monkeypatch):
@@ -39,7 +39,7 @@ def test_generate_overview_fetches_missing_price(monkeypatch):
     )
 
     result = generate_overview(['MSFT'], reddit_posts={'MSFT': []})
-    assert 'MSFT: 42.00 USD (21.00 EUR)' in result
+    assert 'Preis: 42.00 USD | 21.00 EUR' in result
 
 
 def test_generate_overview_includes_latest_sentiment(monkeypatch, tmp_path):
@@ -64,7 +64,7 @@ def test_generate_overview_includes_latest_sentiment(monkeypatch, tmp_path):
     )
 
     result = generate_overview(['NVDA'], reddit_posts={'NVDA': []})
-    assert 'Sentiment (1d, weighted): +0.50' in result
+    assert 'Sentiment 1d: +0.50' in result
 
 
 def test_generate_overview_lists_aliases(monkeypatch, tmp_path):
@@ -114,7 +114,7 @@ def test_generate_overview_includes_trending_section(monkeypatch, tmp_path):
     )
 
     result = generate_overview(['TSLA'], reddit_posts={'TSLA': []})
-    assert '🔥 Trends heute' in result
+    assert '🔥 Reddit Trends:' in result
     assert '- TSLA: 5 Mentions' in result
     assert '7d +5.0%' in result
 
@@ -142,7 +142,7 @@ def test_generate_overview_lists_multi_hits(monkeypatch, tmp_path):
     result = generate_overview(
         ['MSFT'], reddit_posts={'NVDA': [{}, {}]}
     )
-    assert '🔁 Mehrfach erwähnt' in result
+    assert '🔁 Mehrfach erwähnt:' in result
     assert '- NVDA: 2 Posts, 7d +5.0%' in result
     assert 'NVDA' in captured['symbols']
 
@@ -165,7 +165,7 @@ def test_generate_overview_includes_weekly_line(monkeypatch, tmp_path):
     )
 
     result = generate_overview(['AMZN'], reddit_posts={'AMZN': []})
-    assert 'Kurs (7d): +12.0%' in result
+    assert 'Trend 7d: +12.0%' in result
 
 
 def test_generate_overview_includes_ml_predictions(monkeypatch, tmp_path):
@@ -196,10 +196,9 @@ def test_generate_overview_includes_ml_predictions(monkeypatch, tmp_path):
     )
 
     result = generate_overview(['NVDA'], reddit_posts={'NVDA': []})
-    assert 'ML Kaufkandidaten' in result
-    assert 'NVDA: 72.0% Aufwärtschance' in result
-    assert 'Erwartet +1.50%' in result
+    assert '🚦 ML Signale (1d Horizont):' in result
+    assert '- NVDA: 72.0% Conviction' in result
+    assert 'Erwartung +1.50%' in result
     assert 'Backtest Ø +2.00%' in result
     assert 'Trefferquote 60.0%' in result
-    assert 'Acc 0.68' in result and 'F1 0.62' in result
-    assert 'Stand 2024-03-01' in result
+    assert 'ml-v2' in result


### PR DESCRIPTION
## Summary
- streamline the generated Telegram overview with clearer sections for trends, signals, and per-ticker metrics
- surface both buy and sell ML signals with richer confidence and backtest stats and add intraday price change context
- update overview tests to align with the refreshed message structure and terminology

## Testing
- PYTHONPATH=. pytest tests/test_overview.py

------
https://chatgpt.com/codex/tasks/task_e_68de4b0dcbc083258a3b8cc664d702bd