### PR TITLE
Split overview into compact and detailed Telegram messages

### DIFF
--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -15,7 +15,7 @@ from telegram.ext import (
 from main import run_pipeline
 from wallenstein.config import settings, validate_config
 from wallenstein.db import init_schema
-from wallenstein.overview import generate_overview
+from wallenstein.overview import OverviewMessage, generate_overview
 from wallenstein.trending import fetch_weekly_returns
 from wallenstein.watchlist import add_ticker, list_tickers, remove_ticker
 
@@ -79,7 +79,13 @@ async def handle_ticker(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
 
     try:
         overview = generate_overview([ticker])
-        await update.message.reply_text(overview)
+        if isinstance(overview, OverviewMessage):
+            if overview.compact:
+                await update.message.reply_text(overview.compact)
+            if overview.detailed:
+                await update.message.reply_text(overview.detailed)
+        else:  # pragma: no cover - backwards compatibility safety
+            await update.message.reply_text(str(overview))
     except Exception as exc:  # pragma: no cover
         await update.message.reply_text(f"Fehler beim Abrufen von {ticker}: {exc}")
 

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -12,7 +12,7 @@ os.environ.setdefault('TELEGRAM_BOT_TOKEN', 'x')
 from wallenstein.overview import generate_overview
 
 
-def test_generate_overview_starts_with_chart_emoji(monkeypatch):
+def test_generate_overview_has_compact_intro(monkeypatch):
     def fake_get_latest_prices(db_path, tickers, use_eur=False):
         return {t: (1.11 if use_eur else 2.22) for t in tickers}
 
@@ -23,7 +23,8 @@ def test_generate_overview_starts_with_chart_emoji(monkeypatch):
     )
 
     result = generate_overview(['NVDA'], reddit_posts={'NVDA': []})
-    assert result.startswith("📊 Wallenstein Übersicht\n")
+    assert result.compact.startswith("⚡️ Schnellüberblick\n")
+    assert 'Top Kauf-Signale:' in result.compact
 
 
 def test_generate_overview_fetches_missing_price(monkeypatch):
@@ -39,7 +40,7 @@ def test_generate_overview_fetches_missing_price(monkeypatch):
     )
 
     result = generate_overview(['MSFT'], reddit_posts={'MSFT': []})
-    assert 'MSFT: 42.00 USD (21.00 EUR)' in result
+    assert 'Preis: 42.00 USD | 21.00 EUR' in result.detailed
 
 
 def test_generate_overview_includes_latest_sentiment(monkeypatch, tmp_path):
@@ -64,7 +65,7 @@ def test_generate_overview_includes_latest_sentiment(monkeypatch, tmp_path):
     )
 
     result = generate_overview(['NVDA'], reddit_posts={'NVDA': []})
-    assert 'Sentiment (1d, weighted): +0.50' in result
+    assert 'Sentiment 1d: +0.50' in result.detailed
 
 
 def test_generate_overview_lists_aliases(monkeypatch, tmp_path):
@@ -89,7 +90,7 @@ def test_generate_overview_lists_aliases(monkeypatch, tmp_path):
     )
 
     result = generate_overview(['NVDA'], reddit_posts={'NVDA': []})
-    assert 'Alias: nvidia' in result
+    assert 'Alias: nvidia' in result.detailed
 
 
 def test_generate_overview_includes_trending_section(monkeypatch, tmp_path):
@@ -114,9 +115,10 @@ def test_generate_overview_includes_trending_section(monkeypatch, tmp_path):
     )
 
     result = generate_overview(['TSLA'], reddit_posts={'TSLA': []})
-    assert '🔥 Trends heute' in result
-    assert '- TSLA: 5 Mentions' in result
-    assert '7d +5.0%' in result
+    text = str(result)
+    assert '🔥 Reddit Trends:' in text
+    assert '- TSLA: 5 Mentions' in text
+    assert '7d +5.0%' in text
 
 
 def test_generate_overview_lists_multi_hits(monkeypatch, tmp_path):
@@ -142,11 +144,12 @@ def test_generate_overview_lists_multi_hits(monkeypatch, tmp_path):
     result = generate_overview(
         ['MSFT'], reddit_posts={'NVDA': [{}, {}]}
     )
-    assert '🔁 Mehrfach erwähnt' in result
-    assert '- NVDA: 2 Posts, 7d +5.0%' in result
+    detail = result.detailed
+    assert '🔁 Mehrfach erwähnt:' in detail
+    assert '- NVDA: 2 Posts, 7d +5.0%' in detail
     assert 'NVDA' in captured['symbols']
 
-    assert '- NVDA: 2 Posts' in result
+    assert '- NVDA: 2 Posts' in detail
 
 
 
@@ -165,7 +168,7 @@ def test_generate_overview_includes_weekly_line(monkeypatch, tmp_path):
     )
 
     result = generate_overview(['AMZN'], reddit_posts={'AMZN': []})
-    assert 'Kurs (7d): +12.0%' in result
+    assert 'Trend 7d: +12.0%' in result.detailed
 
 
 def test_generate_overview_includes_ml_predictions(monkeypatch, tmp_path):
@@ -196,10 +199,10 @@ def test_generate_overview_includes_ml_predictions(monkeypatch, tmp_path):
     )
 
     result = generate_overview(['NVDA'], reddit_posts={'NVDA': []})
-    assert 'ML Kaufkandidaten' in result
-    assert 'NVDA: 72.0% Aufwärtschance' in result
-    assert 'Erwartet +1.50%' in result
-    assert 'Backtest Ø +2.00%' in result
-    assert 'Trefferquote 60.0%' in result
-    assert 'Acc 0.68' in result and 'F1 0.62' in result
-    assert 'Stand 2024-03-01' in result
+    detail = result.detailed
+    assert '🚦 ML Signale (1d Horizont):' in str(result)
+    assert '- NVDA: 72.0% Conviction' in detail
+    assert 'Erwartung +1.50%' in detail
+    assert 'Backtest Ø +2.00%' in detail
+    assert 'Trefferquote 60.0%' in detail
+    assert 'ml-v2' in detail

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -28,6 +28,8 @@ import importlib
 import wallenstein.config as config_module
 importlib.reload(config_module)
 
+from wallenstein.overview import OverviewMessage
+
 from telegram_bot import cmd_add, cmd_alerts, cmd_list, cmd_remove, handle_ticker
 
 
@@ -48,7 +50,7 @@ def test_handle_ticker(monkeypatch):
 
     def fake_overview(tickers):
         called['overview'] = tickers
-        return 'OVERVIEW'
+        return OverviewMessage(compact='COMPACT', detailed='DETAIL')
 
     async def fake_run_in_executor(executor, func, tickers):
         func(tickers)
@@ -63,7 +65,7 @@ def test_handle_ticker(monkeypatch):
     asyncio.run(handle_ticker(update, context))
     assert called['pipeline'] == ['NVDA']
     assert called['overview'] == ['NVDA']
-    assert update.message.replies == ['OVERVIEW']
+    assert update.message.replies == ['COMPACT', 'DETAIL']
 
 
 def test_cmd_add(monkeypatch):


### PR DESCRIPTION
## Summary
- wrap the overview output in a new `OverviewMessage` container that exposes separate compact and detailed sections while keeping a combined string representation
- update the pipeline and Telegram bot to send the quick-buy summary and the detailed market breakdown as two consecutive messages
- adjust overview and bot tests to exercise the new container API and ensure both messages are delivered

## Testing
- PYTHONPATH=. pytest tests/test_overview.py tests/test_telegram_bot.py

------
https://chatgpt.com/codex/tasks/task_e_68de4b0dcbc083258a3b8cc664d702bd