### PR TITLE
Clean overview output formatting

### DIFF
--- a/wallenstein/overview.py
+++ b/wallenstein/overview.py
@@ -95,11 +95,6 @@ def generate_overview(
     detail_lines: list[str] = ["📊 Wallenstein Markt-Update"]
 
 
-    detail_lines: list[str] = ["📊 Wallenstein Markt-Update"]
-
-    lines = ["📊 Wallenstein Markt-Update"]
-
-
     multi_hits: list[tuple[str, int]] = []
     multi_hit_symbols: list[str] = []
     if reddit_posts:
@@ -150,18 +145,8 @@ def generate_overview(
 
         # --- ML Signale (Buy/Sell) ---
         if trending_rows:
-
             detail_lines.append("")
             detail_lines.append("🔥 Reddit Trends:")
-
-
-            detail_lines.append("")
-            detail_lines.append("🔥 Reddit Trends:")
-
-            lines.append("")
-            lines.append("🔥 Reddit Trends:")
-
-
             for ticker, mentions, avg_up, hotness in trending_rows:
                 avg_val = float(avg_up) if avg_up is not None else 0.0
                 emoji = _hotness_to_emoji(hotness)
@@ -174,17 +159,8 @@ def generate_overview(
                 detail_lines.append(entry)
 
         if multi_hits:
-
             detail_lines.append("")
             detail_lines.append("🔁 Mehrfach erwähnt:")
-
-
-            detail_lines.append("")
-            detail_lines.append("🔁 Mehrfach erwähnt:")
-
-            lines.append("")
-            lines.append("🔁 Mehrfach erwähnt:")
-
             for ticker, count in multi_hits:
                 entry = f"- {ticker}: {count} Posts"
                 weekly = weekly_map.get(str(ticker).upper()) if weekly_map else None
@@ -265,15 +241,9 @@ def generate_overview(
 
             detail_lines.append("")
             detail_lines.append("🚦 ML Signale (1d Horizont):")
+
             if buy_rows:
                 detail_lines.append("✅ Kauf:")
-
-
-            lines.append("")
-            lines.append("🚦 ML Signale (1d Horizont):")
-            if buy_rows:
-                lines.append("✅ Kauf:")
-
 
                 for ticker, _signal, confidence, expected_return, as_of, version in buy_rows:
                     ticker_str = str(ticker).upper()
@@ -298,17 +268,9 @@ def generate_overview(
                         parts.append(str(version))
 
                     detail_lines.append("- " + ticker_str + ": " + ", ".join(parts))
+
             if sell_rows:
                 detail_lines.append("⛔ Verkauf:")
-
-
-                    detail_lines.append("- " + ticker_str + ": " + ", ".join(parts))
-            if sell_rows:
-                detail_lines.append("⛔ Verkauf:")
-
-                    lines.append("- " + ticker_str + ": " + ", ".join(parts))
-            if sell_rows:
-                lines.append("⛔ Verkauf:")
 
                 for ticker, _signal, confidence, expected_return, as_of, version in sell_rows:
                     ticker_str = str(ticker).upper()
@@ -334,7 +296,6 @@ def generate_overview(
 
                     detail_lines.append("- " + ticker_str + ": " + ", ".join(parts))
 
-        if buy_rows or sell_rows:
             detail_lines.append("")
 
         # Preis- und Change-Daten vorbereiten
@@ -457,57 +418,12 @@ def generate_overview(
         trend_summary = _format_trend_summary()
         if trend_summary:
             compact_lines.append(trend_summary)
-
-
-                    lines.append("- " + ticker_str + ": " + ", ".join(parts))
-
-        if buy_rows or sell_rows:
-            lines.append("")
-
-
-
-        # Preis- und Change-Daten vorbereiten
-        price_source = None
-        for candidate in ("stocks", "stocks_view", "prices"):
-            try:
-                con.execute(f"SELECT 1 FROM {candidate} LIMIT 1")
-            except duckdb.Error:
-                continue
-            price_source = candidate
-            break
-
-        change_map: dict[str, tuple[float | None, float | None]] = {}
-        if price_source and tickers:
-            placeholders = ",".join("?" for _ in tickers)
-            try:
-                change_rows = con.execute(
-                    f"""
-                    WITH ranked AS (
-                        SELECT ticker, close, date,
-                               ROW_NUMBER() OVER (PARTITION BY ticker ORDER BY date DESC) rn
-                        FROM {price_source}
-                        WHERE ticker IN ({placeholders})
-                    )
-                    SELECT ticker,
-                           MAX(CASE WHEN rn = 1 THEN close END) AS last_close,
-                           MAX(CASE WHEN rn = 2 THEN close END) AS prev_close
-                    FROM ranked
-                    GROUP BY ticker
-                    """,
-                    tickers,
-                ).fetchall()
-            except duckdb.Error:
-                change_rows = []
-            for ticker, last_close, prev_close in change_rows:
-                change_map[str(ticker).upper()] = (
-                    float(last_close) if last_close is not None else None,
-                    float(prev_close) if prev_close is not None else None,
-                )
-
         for t in tickers:
+            ticker_upper = t.upper()
             usd = prices_usd.get(t)
             eur = prices_eur.get(t)
             detail_lines.append(f"📈 {t}")
+
             try:
                 alias_rows = con.execute(
                     "SELECT alias FROM ticker_aliases WHERE ticker = ? ORDER BY alias",
@@ -517,15 +433,9 @@ def generate_overview(
                 alias_rows = []
             aliases = ", ".join(a for a, in alias_rows if a)
             if aliases:
-
                 detail_lines.append(f"Alias: {aliases}")
 
-
-                detail_lines.append(f"Alias: {aliases}")
-
-                lines.append(f"Alias: {aliases}")
-
-            change_tuple = change_map.get(t.upper())
+            change_tuple = change_map.get(ticker_upper)
             change_pct: float | None = None
             if change_tuple:
                 last_close, prev_close = change_tuple
@@ -541,22 +451,9 @@ def generate_overview(
                 price_bits.append(f"1d {change_pct:+.2f}%")
             detail_lines.append("Preis: " + (" | ".join(price_bits) if price_bits else "n/a"))
 
-
-            weekly = weekly_map.get(str(t).upper()) if weekly_map else None
+            weekly = weekly_map.get(ticker_upper) if weekly_map else None
             if weekly is not None:
                 detail_lines.append(f"Trend 7d: {weekly * 100:+.1f}%")
-
-
-            weekly = weekly_map.get(str(t).upper()) if weekly_map else None
-            if weekly is not None:
-                detail_lines.append(f"Trend 7d: {weekly * 100:+.1f}%")
-            lines.append("Preis: " + (" | ".join(price_bits) if price_bits else "n/a"))
-
-            weekly = weekly_map.get(str(t).upper()) if weekly_map else None
-            if weekly is not None:
-                lines.append(f"Trend 7d: {weekly * 100:+.1f}%")
-
-
 
             try:
                 sent_row = con.execute(
@@ -570,14 +467,7 @@ def generate_overview(
             except duckdb.Error:
                 sent_row = None
             w_sent = sent_row[1] if sent_row and sent_row[1] is not None else 0.0
-
             detail_lines.append(f"Sentiment 7d: {w_sent:+.2f}")
-
-
-            detail_lines.append(f"Sentiment 7d: {w_sent:+.2f}")
-
-            lines.append(f"Sentiment 7d: {w_sent:+.2f}")
-
 
             try:
                 sent_row_1d = con.execute(
@@ -588,8 +478,6 @@ def generate_overview(
                 sent_row_1d = None
             if sent_row_1d and sent_row_1d[0] is not None:
                 detail_lines.append(f"Sentiment 1d: {sent_row_1d[0]:+.2f}")
-      lines.append(f"Sentiment 1d: {sent_row_1d[0]:+.2f}")
-
 
             try:
                 sent_row_24h = con.execute(
@@ -604,9 +492,6 @@ def generate_overview(
                 sent_row_24h = None
             if sent_row_24h and sent_row_24h[0] is not None:
                 detail_lines.append(f"Sentiment 24h: {sent_row_24h[0]:+.2f}")
-
-                lines.append(f"Sentiment 24h: {sent_row_24h[0]:+.2f}")
-
 
             try:
                 trend_today = con.execute(
@@ -635,7 +520,7 @@ def generate_overview(
             if emoji:
                 detail_lines.append(f"Hotness: {emoji}")
 
-            ticker_signal = latest_signals.get(t.upper())
+            ticker_signal = latest_signals.get(ticker_upper)
             if ticker_signal and ticker_signal.get("signal"):
                 sig = str(ticker_signal["signal"]).upper()
                 parts: list[str] = [sig]
@@ -649,23 +534,6 @@ def generate_overview(
                 if version_val:
                     parts.append(str(version_val))
                 detail_lines.append("Signal: " + ", ".join(parts))
-
-
-            ticker_signal = latest_signals.get(t.upper())
-            if ticker_signal and ticker_signal.get("signal"):
-                sig = str(ticker_signal["signal"]).upper()
-                parts: list[str] = [sig]
-                conf_val = ticker_signal.get("confidence")
-                if isinstance(conf_val, (int, float)):
-                    parts.append(f"{float(conf_val) * 100:.1f}% Conviction")
-                exp_val = ticker_signal.get("expected_return")
-                if isinstance(exp_val, (int, float)):
-                    parts.append(f"Erwartung {float(exp_val) * 100:+.2f}%")
-                version_val = ticker_signal.get("version")
-                if version_val:
-                    parts.append(str(version_val))
-                lines.append("Signal: " + ", ".join(parts))
-
 
             try:
                 top_post = con.execute(
@@ -687,10 +555,3 @@ def generate_overview(
     compact_text = "\n".join(compact_lines).strip()
     detail_text = "\n".join(detail_lines).strip()
     return OverviewMessage(compact=compact_text, detailed=detail_text)
-
-    segments = []
-    if compact_lines:
-        segments.append("\n".join(compact_lines).strip())
-    if detail_lines:
-        segments.append("\n".join(detail_lines).strip())
-    return "\n\n".join(seg for seg in segments if seg).strip()


### PR DESCRIPTION
## Summary
- remove the unused secondary lines buffer and deduplicate repeated append calls in the overview
- simplify the ML signal rendering with properly nested buy/sell loops and clean headers
- streamline per-ticker details so aliases, sentiment, and metrics are appended once

## Testing
- python -m compileall wallenstein/overview.py

------
https://chatgpt.com/codex/tasks/task_e_68de89227158832584a422053c7a4495