### PR TITLE
Enhance ML buy recommendations with composite signal score

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@
 - Removed deprecated functions `_select_latest_prices` and `get_latest_prices_auto` from `wallenstein.db_utils`.
 - Stored ML-based buy signals with probabilities/backtests and surfaced them in the overview output.
 - Enriched ML buy-signal metadata with expected returns, win rates and calibration details; overview now highlights expected vs. backtested performance.
+- Added probability margins plus a composite signal-strength score and surfaced both in the overview summaries.

--- a/README.md
+++ b/README.md
@@ -153,6 +153,29 @@ ticker and day (mean, weighted mean and median) and stored in DuckDB's
 The sentiment engine runs without `transformers` or `torch`; in that case the
 VADER path is used transparently.
 
+## Kaufempfehlungen optimieren
+
+- **Signal-Score**: Die ML-Pipeline schreibt neben Wahrscheinlichkeit und
+  erwarteter Rendite jetzt auch eine `probability_margin` sowie einen
+  zusammengesetzten `signal_strength`-Score (40 % Konfidenz, 25 %
+  Erwartungsrendite, 15 % Margin, 10 % Backtest-Alpha, 10 % Trefferquote). Die
+  Übersicht sortiert Kaufempfehlungen damit automatisch nach Qualität und zeigt
+  Margin/Score direkt an.
+- **Open-Source-Referenzen**: Projekte wie [OpenBB
+  Terminal](https://github.com/OpenBB-finance/OpenBBTerminal),
+  [FinRL](https://github.com/AI4Finance-LLC/FinRL) oder das
+  [Lean-Backtesting-Framework von QuantConnect](https://github.com/QuantConnect/Lean)
+  verfolgen ähnliche Multi-Signal-Setups mit Backtests und Risikokennzahlen. Die
+  dort genutzten Ensembling-Strategien, Walk-Forward-Splits und Risiko-KPI
+  (z. B. Sharpe/Sortino) lassen sich leicht adaptieren.
+- **Weitere Ausbaustufen**: Für mehr Robustheit empfiehlt sich ein
+  Signal-Ensemble (z. B. Gradient Boosting + Time-Series Forest), ein
+  Probability-Calibrator (Isotonic/Platt), Faktor-/Makrodaten als zusätzliche
+  Features und ein laufender Vergleich gegen Risiko-Benchmarks (Max Drawdown,
+  Hit Rate pro Volatilitätsregime). Zudem können Optuna-Studien oder AutoML
+  Pipelines (vgl. AutoGluon) helfen, neue Modellvarianten automatisiert zu
+  testen.
+
 ## Dynamic Watchlist + Telegram Bot
 
 Expose ``TELEGRAM_BOT_TOKEN`` and ``TELEGRAM_CHAT_ID`` (override the database path with ``WALLENSTEIN_DB_PATH`` if needed) and start the bot with:

--- a/main.py
+++ b/main.py
@@ -581,6 +581,7 @@ def train_models(tickers: list[str], reddit_posts: dict[str, list]) -> None:
                         expected_return = meta.get("expected_return")
                         backtest_return = meta.get("avg_strategy_return")
                         probability_margin = meta.get("probability_margin")
+                        signal_strength = meta.get("signal_strength")
                         if expected_return is None:
                             expected_return = backtest_return
                         try:
@@ -595,6 +596,8 @@ def train_models(tickers: list[str], reddit_posts: dict[str, list]) -> None:
                                         "confidence": confidence,
                                         "expected_return": expected_return,
                                         "version": version,
+                                        "probability_margin": probability_margin,
+                                        "signal_strength": signal_strength,
                                     }
                                 ],
                             )
@@ -607,6 +610,9 @@ def train_models(tickers: list[str], reddit_posts: dict[str, list]) -> None:
                                     expected_return if expected_return is not None else float("nan"),
                                     backtest_return if backtest_return is not None else float("nan"),
                                     probability_margin if probability_margin is not None else float("nan"),
+                                )
+                                log.info(
+                                    "%s: Signal strength %.2f", t, signal_strength if signal_strength is not None else float("nan")
                                 )
                         except Exception as exc:  # pragma: no cover - DB best effort
                             log.warning("%s: Prediction storage failed: %s", t, exc)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -41,12 +41,16 @@ def test_train_per_stock_basic():
     assert "expected_return" in info
     assert "long_win_rate" in info
     assert "probability_margin" in info
+    assert "signal_strength" in info
     expected = info.get("expected_return")
     if expected is not None:
         assert -1.0 < expected < 1.0
     win_rate = info.get("long_win_rate")
     if win_rate is not None:
         assert 0.0 <= win_rate <= 1.0
+    signal_strength = info.get("signal_strength")
+    if signal_strength is not None:
+        assert signal_strength >= 0.0
 
 
 def test_train_per_stock_smote():

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -201,13 +201,13 @@ def test_generate_overview_includes_ml_predictions(monkeypatch, tmp_path):
     db_path = tmp_path / 'db.duckdb'
     con = duckdb.connect(str(db_path))
     con.execute(
-        "CREATE TABLE predictions (as_of TIMESTAMP, ticker TEXT, horizon_days INT, signal TEXT, confidence DOUBLE, expected_return DOUBLE, version TEXT)"
+        "CREATE TABLE predictions (as_of TIMESTAMP, ticker TEXT, horizon_days INT, signal TEXT, confidence DOUBLE, expected_return DOUBLE, version TEXT, probability_margin DOUBLE, signal_strength DOUBLE)"
     )
     con.execute(
         "CREATE TABLE model_training_state (ticker TEXT, latest_price_date DATE, price_row_count INT, latest_sentiment_date DATE, sentiment_row_count INT, latest_post_utc TIMESTAMP, trained_at TIMESTAMP, accuracy DOUBLE, f1 DOUBLE, roc_auc DOUBLE, precision_score DOUBLE, recall_score DOUBLE, avg_strategy_return DOUBLE, long_win_rate DOUBLE)"
     )
     con.execute(
-        "INSERT INTO predictions VALUES (TIMESTAMP '2024-03-01 12:00:00', 'NVDA', 1, 'buy', 0.72, 0.015, 'ml-v2')"
+        "INSERT INTO predictions VALUES (TIMESTAMP '2024-03-01 12:00:00', 'NVDA', 1, 'buy', 0.72, 0.015, 'ml-v2', 0.12, 31.9)"
     )
     con.execute(
         "INSERT INTO model_training_state VALUES ('NVDA', CURRENT_DATE, 100, CURRENT_DATE, 80, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 0.68, 0.62, 0.70, 0.64, 0.59, 0.02, 0.6)"
@@ -229,6 +229,8 @@ def test_generate_overview_includes_ml_predictions(monkeypatch, tmp_path):
     assert '🚦 ML Signale (1d Horizont):' in str(result)
     assert '- NVDA: 72.0% Conviction' in detail
     assert 'Erwartung +1.50%' in detail
+    assert 'Margin +12.0pp' in detail
+    assert 'Score 31.9' in detail
     assert 'Backtest Ø +2.00%' in detail
     assert 'Trefferquote 60.0%' in detail
     assert 'ml-v2' in detail

--- a/wallenstein/db_schema.py
+++ b/wallenstein/db_schema.py
@@ -67,6 +67,8 @@ SCHEMAS = {
         "confidence": "DOUBLE",
         "expected_return": "DOUBLE",
         "version": "TEXT",
+        "probability_margin": "DOUBLE",
+        "signal_strength": "DOUBLE",
     },
     "fx_rates": {
         "date": "DATE",
@@ -173,6 +175,18 @@ def ensure_tables(con: duckdb.DuckDBPyConnection):
             if "expected_return" not in cols_existing:
                 try:
                     con.execute("ALTER TABLE predictions ADD COLUMN expected_return DOUBLE")
+                except duckdb.Error:
+                    pass
+            if "probability_margin" not in cols_existing:
+                try:
+                    con.execute(
+                        "ALTER TABLE predictions ADD COLUMN probability_margin DOUBLE"
+                    )
+                except duckdb.Error:
+                    pass
+            if "signal_strength" not in cols_existing:
+                try:
+                    con.execute("ALTER TABLE predictions ADD COLUMN signal_strength DOUBLE")
                 except duckdb.Error:
                     pass
             try:


### PR DESCRIPTION
## Summary
- add probability margins and a composite signal-strength score to the ML metadata and persist both in DuckDB
- sort and annotate overview buy/sell sections with the new metrics and document optimisation approaches with references to similar OSS projects
- update tests to reflect the richer output

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68dea4c823bc832593cbbbb5c634166f